### PR TITLE
Fix/refactor model-loading fixtures and utilities

### DIFF
--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -6,7 +6,7 @@ from shutil import copytree
 from typing import Dict, List, Optional
 
 import pytest
-from modflow_devtools.misc import get_mf6_ftypes, get_models
+from modflow_devtools.misc import get_model_paths, get_packages
 
 # temporary directory fixtures
 
@@ -174,7 +174,7 @@ def pytest_generate_tests(metafunc):
     key = "test_model_mf6"
     if key in metafunc.fixturenames:
         models = (
-            get_models(
+            get_model_paths(
                 Path(repos_path) / "modflow6-testmodels" / "mf6",
                 prefix="test",
                 excluded=["test205_gwtbuy-henrytidal"],
@@ -189,7 +189,7 @@ def pytest_generate_tests(metafunc):
     key = "test_model_mf5to6"
     if key in metafunc.fixturenames:
         models = (
-            get_models(
+            get_model_paths(
                 Path(repos_path) / "modflow6-testmodels" / "mf5to6",
                 prefix="test",
                 namefile="*.nam",
@@ -205,7 +205,7 @@ def pytest_generate_tests(metafunc):
     key = "large_test_model"
     if key in metafunc.fixturenames:
         models = (
-            get_models(
+            get_model_paths(
                 Path(repos_path) / "modflow6-largetestmodels",
                 prefix="test",
                 namefile="*.nam",
@@ -292,7 +292,7 @@ def pytest_generate_tests(metafunc):
                 for name, namefiles in examples.items():
                     ftypes = []
                     for namefile in namefiles:
-                        ftype = get_mf6_ftypes(namefile, packages_selected)
+                        ftype = get_packages(namefile, packages_selected)
                         if ftype not in ftypes:
                             ftypes += ftype
                     if len(ftypes) > 0:

--- a/modflow_devtools/test/test_executables.py
+++ b/modflow_devtools/test/test_executables.py
@@ -7,17 +7,12 @@ import pytest
 from modflow_devtools.executables import Executables
 from modflow_devtools.misc import add_sys_path, get_suffixes
 
-_bin_path = Path(environ.get("BIN_PATH")).expanduser()
+_bin_path = Path(environ.get("BIN_PATH")).expanduser().absolute()
 _ext, _ = get_suffixes(sys.platform)
 
 
-@pytest.fixture
-def bin_path(module_tmpdir) -> Path:
-    return _bin_path.absolute()
-
-
 @pytest.mark.skipif(not _bin_path.is_dir(), reason="bin directory not found")
-def test_get_path(bin_path):
+def test_get_path():
     with add_sys_path(str(_bin_path)):
         ext, _ = get_suffixes(sys.platform)
         assert (
@@ -26,22 +21,22 @@ def test_get_path(bin_path):
         )
 
 
-def test_get_version(bin_path):
-    with add_sys_path(str(bin_path)):
-        ver_str = Executables.get_version("mf6", path=bin_path).partition(" ")
+def test_get_version():
+    with add_sys_path(str(_bin_path)):
+        ver_str = Executables.get_version("mf6", path=_bin_path).partition(" ")
         print(ver_str)
         version = int(ver_str[0].split(".")[0])
         assert version >= 6
 
 
 @pytest.fixture
-def exes(bin_path):
-    return Executables(mf6=bin_path / f"mf6{_ext}")
+def exes():
+    return Executables(mf6=_bin_path / f"mf6{_ext}")
 
 
-def test_executables_mapping(bin_path, exes):
+def test_executables_mapping(exes):
     print(exes.mf6)
-    assert exes.mf6 == bin_path / f"mf6{_ext}"
+    assert exes.mf6 == _bin_path / f"mf6{_ext}"
 
 
 def test_executables_usage(exes):

--- a/modflow_devtools/test/test_fixtures.py
+++ b/modflow_devtools/test/test_fixtures.py
@@ -254,9 +254,11 @@ def test_test_model_mf6(test_model_mf6):
 
 def test_test_model_mf5to6(test_model_mf5to6):
     assert isinstance(test_model_mf5to6, Path)
-    assert len(list(test_model_mf5to6.glob("*.nam"))) >= 1
+    assert any(list(test_model_mf5to6.glob("*.nam")))
 
 
 def test_large_test_model(large_test_model):
     assert isinstance(large_test_model, Path)
-    assert (large_test_model / "mfsim.nam").is_file()
+    assert (large_test_model / "mfsim.nam").is_file() or any(
+        list(large_test_model.glob("*.nam"))
+    )

--- a/modflow_devtools/test/test_misc.py
+++ b/modflow_devtools/test/test_misc.py
@@ -1,2 +1,59 @@
-def test_set_dir():
-    pass
+import os
+from os import environ
+from pathlib import Path
+
+import pytest
+from modflow_devtools.misc import get_model_paths, get_packages, set_dir
+
+
+def test_set_dir(tmp_path):
+    assert Path(os.getcwd()) != tmp_path
+    with set_dir(tmp_path):
+        assert Path(os.getcwd()) == tmp_path
+    assert Path(os.getcwd()) != tmp_path
+
+
+_repos_path = Path(environ.get("REPOS_PATH")).expanduser().absolute()
+_examples_repo_path = _repos_path / "modflow6-examples"
+_examples_path = _examples_repo_path / "examples"
+_example_paths = (
+    sorted(list(_examples_path.glob("ex-*")))
+    if _examples_path.is_dir()
+    else []
+)
+
+
+@pytest.mark.skipif(not any(_example_paths), reason="examples not found")
+def test_has_packages():
+    example_path = _example_paths[0]
+    packages = get_packages(example_path / "mfsim.nam")
+    assert set(packages) == {"tdis", "gwf", "ims"}
+
+
+@pytest.mark.skipif(not any(_example_paths), reason="examples not found")
+def test_get_model_paths():
+    paths = get_model_paths(_examples_path)
+    assert len(paths) == 127
+
+    paths = get_model_paths(_examples_path, namefile="*.nam")
+    assert len(paths) == 339
+
+
+def test_get_model_paths_exclude_patterns():
+    paths = get_model_paths(_examples_path, excluded=["gwt"])
+    assert len(paths) == 63
+
+
+def test_get_model_paths_select_prefix():
+    paths = get_model_paths(_examples_path, prefix="ex2")
+    assert not any(paths)
+
+
+def test_get_model_paths_select_patterns():
+    paths = get_model_paths(_examples_path, selected=["gwf"])
+    assert len(paths) == 70
+
+
+def test_get_model_paths_select_packages():
+    paths = get_model_paths(_examples_path, namefile="*.nam", packages=["wel"])
+    assert len(paths) == 64


### PR DESCRIPTION
* rename `modflow_devtools.misc.get_models` to `get_model_paths`
* fix `get_model_paths` filtering by package
* sort paths returned by `get_model_paths`
* refactor `get_packages` function
* expand tests