### PR TITLE
feat(build): restore meson_build function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-22.04, macos-12, windows-2022 ]
         python: [ 3.7, 3.8, 3.9, "3.10" ]
+    env:
+      GCC_V: 11
     steps:
 
       - name: Checkout repo
@@ -123,6 +125,12 @@ jobs:
 
       - name: Install executables
         uses: modflowpy/install-modflow-action@v1
+
+      - name: Setup GNU Fortran ${{ env.GCC_V }}
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: gcc
+          version: ${{ env.GCC_V }}
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/modflow_devtools/build.py
+++ b/modflow_devtools/build.py
@@ -1,0 +1,31 @@
+import platform
+import subprocess
+from os import PathLike
+from pathlib import Path
+
+from modflow_devtools.misc import set_dir
+
+
+def meson_build(
+    project_path: PathLike,
+    build_path: PathLike,
+    bin_path: PathLike,
+):
+    project_path = Path(project_path).expanduser().absolute()
+    build_path = Path(build_path).expanduser().absolute()
+    bin_path = Path(bin_path).expanduser().absolute()
+
+    with set_dir(Path(project_path)):
+        cmd = (
+            f"meson setup {build_path} "
+            + f"--bindir={bin_path} "
+            + f"--libdir={bin_path} "
+            + f"--prefix={('%CD%' if platform.system() == 'Windows' else '$(pwd)')}"
+            + (" --wipe" if build_path.is_dir() else "")
+        )
+        print(f"Running meson setup command: {cmd}")
+        subprocess.run(cmd, shell=True, check=True)
+
+        cmd = f"meson install -C {build_path}"
+        print(f"Running meson install command: {cmd}")
+        subprocess.run(cmd, shell=True, check=True)

--- a/modflow_devtools/test/test_build.py
+++ b/modflow_devtools/test/test_build.py
@@ -1,0 +1,34 @@
+import platform
+from os import environ
+from pathlib import Path
+
+import pytest
+from modflow_devtools.build import meson_build
+from modflow_devtools.markers import requires_pkg
+
+_repos_path = Path(environ.get("REPOS_PATH")).expanduser().absolute()
+_project_root_path = Path(__file__).parent.parent.parent.parent
+_modflow6_repo_path = _repos_path / "modflow6"
+_system = platform.system()
+_exe_ext = ".exe" if _system == "Windows" else ""
+_lib_ext = (
+    ".so"
+    if _system == "Linux"
+    else (".dylib" if _system == "Darwin" else ".dll")
+)
+
+
+@requires_pkg("meson", "ninja")
+@pytest.mark.skipif(
+    not _modflow6_repo_path.is_dir(), reason="modflow6 repository not found"
+)
+def test_meson_build(tmp_path):
+    build_path = tmp_path / "builddir"
+    bin_path = tmp_path / "bin"
+
+    meson_build(_modflow6_repo_path, build_path, bin_path)
+
+    assert (bin_path / f"mf6{_exe_ext}").is_file()
+    assert (bin_path / f"zbud6{_exe_ext}").is_file()
+    assert (bin_path / f"mf5to6{_exe_ext}").is_file()
+    assert (bin_path / f"libmf6{_lib_ext}").is_file()

--- a/modflow_devtools/test/test_misc.py
+++ b/modflow_devtools/test/test_misc.py
@@ -1,6 +1,7 @@
 import os
 from os import environ
 from pathlib import Path
+from typing import List
 
 import pytest
 from modflow_devtools.misc import get_model_paths, get_packages, set_dir
@@ -32,11 +33,22 @@ def test_has_packages():
 
 @pytest.mark.skipif(not any(_example_paths), reason="examples not found")
 def test_get_model_paths():
-    paths = get_model_paths(_examples_path)
-    assert len(paths) == 127
+    def get_expected(path, pattern="mfsim.nam") -> List[Path]:
+        folders = []
+        for root, dirs, files in os.walk(path):
+            for d in dirs:
+                p = Path(root) / d
+                if any(p.glob(pattern)):
+                    folders.append(p)
+        return sorted(folders)
 
+    expected_paths = get_expected(_examples_path)
+    paths = get_model_paths(_examples_path)
+    assert set(expected_paths) == set(paths)
+
+    expected_paths = get_expected(_examples_path, "*.nam")
     paths = get_model_paths(_examples_path, namefile="*.nam")
-    assert len(paths) == 339
+    assert set(expected_paths) == set(paths)
 
 
 def test_get_model_paths_exclude_patterns():

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ test =
     %(lint)s
     coverage
     flaky
+    meson!=0.63.0
+    ninja
     pytest-cases
     pytest-cov
     pytest-dotenv


### PR DESCRIPTION
This was originally a member method on the test context class, but it's used in enough places to justify being a standalone utility function like in `mfpymake` IMO. I flip-flopped a few times about whether this should live here, but being able to import from this package means MODFLOW 6 distribution scripts don't have to use `mfpymake`, adjust the system path to import from `autotest`, or duplicate a similar function.