### PR TITLE
refactor: drop Python 3.7, add Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: 'pip'
           cache-dependency-path: setup.cfg
 
@@ -56,28 +56,22 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
-      - name: Upgrade pip and install build and twine
+      - name: Install Python packages
         run: |
           pip install --upgrade pip
           pip install build twine
-
-      - name: Base modflow_devtools installation
-        run: |
           pip --verbose install .
 
       - name: Print package version
-        run: |
-          python -c "import modflow_devtools; print(modflow_devtools.__version__)"
+        run: python -c "import modflow_devtools; print(modflow_devtools.__version__)"
 
       - name: Build package
-        run: |
-          python -m build
+        run: python -m build
       
       - name: Check distribution
-        run: |
-          twine check --strict dist/*
+        run: twine check --strict dist/*
 
   test:
     name: Test
@@ -89,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04, macos-12, windows-2022 ]
-        python: [ 3.7, 3.8, 3.9, "3.10" ]
+        python: [ 3.8, 3.9, "3.10", "3.11" ]
     env:
       GCC_V: 11
     steps:
@@ -155,16 +149,14 @@ jobs:
           key: modflow6-examples-${{ hashFiles('modflow6-examples/data/**') }}
       
       - name: Install extra Python packages
-        # can't build examples on Python 3.7, requires Python 3.8
-        if: steps.cache-examples.outputs.cache-hit != 'true' && matrix.python != '3.7'
+        if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc
         run: |
           pip install -r requirements.pip.txt
           pip install -r requirements.usgs.txt
 
       - name: Build modflow6 example models
-        # can't build examples on Python 3.7, requires Python 3.8
-        if: steps.cache-examples.outputs.cache-hit != 'true' && matrix.python != '3.7'
+        if: steps.cache-examples.outputs.cache-hit != 'true'
         working-directory: modflow6-examples/etc
         run: python ci_build_files.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: 'pip'
           cache-dependency-path: setup.cfg
 
@@ -37,7 +37,7 @@ jobs:
           pip install --upgrade pip
           pip install build twine
           pip install .
-          pip install ".[lint, test, optional]"
+          pip install ".[lint, test]"
 
       - name: Update version
         id: version
@@ -173,7 +173,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install Python dependencies
         run: |
@@ -211,7 +211,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
           cache: 'pip'
           cache-dependency-path: setup.cfg
 
@@ -219,7 +219,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install .
-          pip install ".[lint, test, optional]"
+          pip install ".[lint, test]"
 
       - name: Get release tag
         uses: oprypin/find-latest-tag@v1

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -14,6 +14,10 @@ This document provides guidance to set up a development environment and discusse
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## Requirements
+
+Python3.8+ is currently required. This project supports several recent versions of Python, loosely following [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html#implementation) and aiming to stay synchronized with [FloPy](https://github.com/modflowpy/flopy).
+
 ## Installation
 
 To get started, first fork and clone this repository. Then install the project and core packages as well as linting and testing dependencies:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MODFLOW developer tools
 
 ### Version 0.0.7 &mdash; release candidate
-[![GitHub tag](https://img.shields.io/github/tag/MODFLOW-USGS/modflow-devtools.svg)](https://github.com/MODFLOW-USGS/modflow-devtools/tags/latest)
 [![CI](https://github.com/MODFLOW-USGS/modflow-devtools/actions/workflows/ci.yml/badge.svg)](https://github.com/MODFLOW-USGS/modflow-devtools/actions/workflows/ci.yml)
+[![GitHub tag](https://img.shields.io/github/tag/MODFLOW-USGS/modflow-devtools.svg)](https://github.com/MODFLOW-USGS/modflow-devtools/tags/latest)
 [![PyPI Version](https://img.shields.io/pypi/v/modflow-devtools.png)](https://pypi.python.org/pypi/modflow-devtools)
 [![PyPI Status](https://img.shields.io/pypi/status/modflow-devtools.png)](https://pypi.python.org/pypi/modflow-devtools)
 [![PyPI Versions](https://img.shields.io/pypi/pyversions/modflow-devtools.png)](https://pypi.python.org/pypi/modflow-devtools)
@@ -34,7 +34,7 @@ Python tools for MODFLOW development and testing.
 
 ## Requirements
 
-This package requires Python3.7+. Its only dependencies are `numpy` and `pytest`.
+This package requires Python3.8+. Its only dependencies are `numpy` and `pytest`.
 
 ## Installation
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,10 +22,10 @@ classifiers =
     Operating System :: MacOS
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
     Topic :: Scientific/Engineering :: Hydrology
 url = https://github.com/MODFLOW-USGS/modflow-devtools
@@ -39,7 +39,7 @@ project_urls =
 include_package_data = True
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     numpy
     pytest
@@ -73,29 +73,23 @@ exclude =
     dist
     autotest
 ignore =
-# https://flake8.pycqa.org/en/latest/user/error-codes.html
-    F401 # 'module' imported but unused
-# https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
-    E121 # continuation line under-indented for hanging indent
-    E122 # continuation line missing indentation or outdented
-    E126 # continuation line over-indented for hanging indent
-    E127 # continuation line over-indented for visual indent
-    E128 # continuation line under-indented for visual indent
-    E203 # whitespace before
-    E221 # multiple spaces before operator
-    E222 # multiple spaces after operator
-    E226 # missing whitespace around arithmetic operator
-    E231 # missing whitespace after ','
-    E241 # multiple spaces after ','
-    E402 # module level import not at top of file
-    E501 # line too long (> 79 characters)
-    E502 # backslash is redundant between brackets
-    E722 # do not use bare 'except'
-    E741 # ambiguous variable name
-    W291 # trailing whitespace
-    W292 # no newline at end of file
-    W293 # blank line contains whitespace
-    W391 # blank line at end of file
-    W503 # line break before binary operator
-    W504 # line break after binary operator
+    # https://flake8.pycqa.org/en/latest/user/error-codes.html
+    F401,
+    # https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
+    # Indentation
+    E121, E122, E126, E127, E128,
+    # Whitespace
+    E203, E221, E222, E226, E231, E241,
+    # Import
+    E402,
+    # Line length
+    E501, E502,
+    # Statement
+    E722, E741,
+    # Whitespace warning
+    W291, W292, W293,
+    # Blank line warning
+    W391,
+    # Line break warning
+    W503, W504
 statistics = True


### PR DESCRIPTION
Drop Python 3.7 support and add Python 3.11, aiming to stay in sync [with FloPy](https://github.com/modflowpy/flopy/pull/1662). Also update `setup.cfg` flake8 section, update Python versions in CI test matrix, and briefly describe Python version support strategy in `DEVELOPER.md`.