### PR TITLE
fix(release): exclude intermediate changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,7 @@ jobs:
           # remove this release's changelog so we don't commit it
           # the changes have already been prepended to HISTORY.md
           rm ${{ steps.update-changelog.outputs.changelog }}
+          rm -f CHANGELOG.md
           
           # commit and push changes
           git config core.sharedRepository true


### PR DESCRIPTION
Excludes the `CHANGELOG.md` generated by `git-cliff-action` since we store cumulative changelog in `HISTORY.md`