### PR TITLE
refactor(fixtures): fix/refactor model-loading fixtures

### DIFF
--- a/docs/md/fixtures.md
+++ b/docs/md/fixtures.md
@@ -2,7 +2,7 @@
 
 Several `pytest` fixtures are provided to help with testing.
 
-## Keepable temporary directory fixtures
+## Keepable temporary directories
 
 Tests often need to exercise code that reads from and/or writes to disk. The test harness may also need to create test data during setup and clean up the filesystem on teardown. Temporary directories are built into `pytest` via the [`tmp_path`](https://docs.pytest.org/en/latest/how-to/tmp_path.html#the-tmp-path-fixture) and `tmp_path_factory` fixtures.
 
@@ -40,9 +40,9 @@ pytest --keep <path>
 
 There is also a `--keep-failed <path>` option which preserves outputs only from failing test cases.
 
-## Model-loading fixtures
+## Loading example models
 
-Fixtures are provided to load models from the MODFLOW 6 example and test model repositories and feed them to test functions. Models can be loaded from:
+Fixtures are provided to find and enumerate models from the MODFLOW 6 example and test model repositories and feed them to test functions. Models can be loaded from:
 
 - [`MODFLOW-USGS/modflow6-examples`](https://github.com/MODFLOW-USGS/modflow6-examples)
 - [`MODFLOW-USGS/modflow6-testmodels`](https://github.com/MODFLOW-USGS/modflow6-testmodels)
@@ -61,14 +61,15 @@ To use these fixtures, the environment variable `REPOS_PATH` must point to the l
 
 ### Test models
 
-The `test_model_mf5to6`, `test_model_mf6` and `large_test_model` fixtures are each a `Path` to the directory containing the model's namefile. For instance, to load `mf5to6` models from the [`MODFLOW-USGS/modflow6-testmodels`](https://github.com/MODFLOW-USGS/modflow6-testmodels) repository:
+The `test_model_mf5to6`, `test_model_mf6` and `large_test_model` fixtures are each a `Path` to the model's namefile. For example:, to load `mf5to6` models from the  repository:
 
 ```python
-def test_mf5to6_model(testmodel_mf5to6):
-    assert testmodel_mf5to6.is_dir()
+def test_mf5to6_model(test_model_mf5to6):
+    assert test_model_mf5to6.is_file()
+    assert test_model_mf5to6.suffix == ".nam"
 ```
 
-This test function will be parametrized with all `mf5to6` models found in the `testmodels` repository (likewise for `mf6` models, and for large test models in their own repository).
+This test function will be parametrized with all `mf5to6` models found in the [`MODFLOW-USGS/modflow6-testmodels`](https://github.com/MODFLOW-USGS/modflow6-testmodels).
 
 ### Example scenarios
 
@@ -88,3 +89,12 @@ def test_example_scenario(tmp_path, example_scenario):
         # load and run model
         # ...
 ```
+
+### Utility functions
+
+Model-loading fixtures use a set of utility functions to find and enumerate models. These functions can be imported from `modflow_devtools.misc` for use in other contexts:
+
+- `get_model_dir_paths()`
+- `get_namefile_paths()`
+
+See this project's test suite for usage examples.

--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -6,7 +6,11 @@ from shutil import copytree
 from typing import Dict, List, Optional
 
 import pytest
-from modflow_devtools.misc import get_model_paths, get_packages
+from modflow_devtools.misc import (
+    get_model_dir_paths,
+    get_namefile_paths,
+    get_packages,
+)
 
 # temporary directory fixtures
 
@@ -174,7 +178,7 @@ def pytest_generate_tests(metafunc):
     key = "test_model_mf6"
     if key in metafunc.fixturenames:
         models = (
-            get_model_paths(
+            get_namefile_paths(
                 Path(repos_path) / "modflow6-testmodels" / "mf6",
                 prefix="test",
                 excluded=["test205_gwtbuy-henrytidal"],
@@ -184,12 +188,12 @@ def pytest_generate_tests(metafunc):
             if repos_path
             else []
         )
-        metafunc.parametrize(key, models, ids=[m.name for m in models])
+        metafunc.parametrize(key, models, ids=[str(m) for m in models])
 
     key = "test_model_mf5to6"
     if key in metafunc.fixturenames:
         models = (
-            get_model_paths(
+            get_namefile_paths(
                 Path(repos_path) / "modflow6-testmodels" / "mf5to6",
                 prefix="test",
                 namefile="*.nam",
@@ -200,15 +204,15 @@ def pytest_generate_tests(metafunc):
             if repos_path
             else []
         )
-        metafunc.parametrize(key, models, ids=[m.name for m in models])
+        metafunc.parametrize(key, models, ids=[str(m) for m in models])
 
     key = "large_test_model"
     if key in metafunc.fixturenames:
         models = (
-            get_model_paths(
+            get_namefile_paths(
                 Path(repos_path) / "modflow6-largetestmodels",
                 prefix="test",
-                namefile="*.nam",
+                namefile="mfsim.nam",
                 excluded=[],
                 selected=models_selected,
                 packages=packages_selected,
@@ -216,7 +220,7 @@ def pytest_generate_tests(metafunc):
             if repos_path
             else []
         )
-        metafunc.parametrize(key, models, ids=[m.name for m in models])
+        metafunc.parametrize(key, models, ids=[str(m) for m in models])
 
     key = "example_scenario"
     if key in metafunc.fixturenames:

--- a/modflow_devtools/test/test_fixtures.py
+++ b/modflow_devtools/test/test_fixtures.py
@@ -249,16 +249,18 @@ def test_example_scenario(example_scenario):
 
 def test_test_model_mf6(test_model_mf6):
     assert isinstance(test_model_mf6, Path)
-    assert (test_model_mf6 / "mfsim.nam").is_file()
+    assert test_model_mf6.is_file()
+    assert test_model_mf6.name == "mfsim.nam"
 
 
 def test_test_model_mf5to6(test_model_mf5to6):
     assert isinstance(test_model_mf5to6, Path)
-    assert any(list(test_model_mf5to6.glob("*.nam")))
+    assert test_model_mf5to6.is_file()
+    assert test_model_mf5to6.suffix == ".nam"
 
 
 def test_large_test_model(large_test_model):
+    print(large_test_model)
     assert isinstance(large_test_model, Path)
-    assert (large_test_model / "mfsim.nam").is_file() or any(
-        list(large_test_model.glob("*.nam"))
-    )
+    assert large_test_model.is_file()
+    assert large_test_model.suffix == ".nam"

--- a/modflow_devtools/test/test_misc.py
+++ b/modflow_devtools/test/test_misc.py
@@ -4,7 +4,12 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from modflow_devtools.misc import get_model_paths, get_packages, set_dir
+from modflow_devtools.misc import (
+    get_model_dir_paths,
+    get_namefile_paths,
+    get_packages,
+    set_dir,
+)
 
 
 def test_set_dir(tmp_path):
@@ -15,6 +20,8 @@ def test_set_dir(tmp_path):
 
 
 _repos_path = Path(environ.get("REPOS_PATH")).expanduser().absolute()
+_largetestmodels_repo_path = _repos_path / "modflow6-largetestmodels"
+_largetestmodel_paths = sorted(list(_largetestmodels_repo_path.glob("test*")))
 _examples_repo_path = _repos_path / "modflow6-examples"
 _examples_path = _examples_repo_path / "examples"
 _example_paths = (
@@ -31,45 +38,130 @@ def test_has_packages():
     assert set(packages) == {"tdis", "gwf", "ims"}
 
 
-@pytest.mark.skipif(not any(_example_paths), reason="examples not found")
-def test_get_model_paths():
-    def get_expected(path, pattern="mfsim.nam") -> List[Path]:
-        folders = []
-        for root, dirs, files in os.walk(path):
-            for d in dirs:
-                p = Path(root) / d
-                if any(p.glob(pattern)):
-                    folders.append(p)
-        return sorted(folders)
+def get_expected_model_dirs(path, pattern="mfsim.nam") -> List[Path]:
+    folders = []
+    for root, dirs, files in os.walk(path):
+        for d in dirs:
+            p = Path(root) / d
+            if any(p.glob(pattern)):
+                folders.append(p)
+    return sorted(list(set(folders)))
 
-    expected_paths = get_expected(_examples_path)
-    paths = get_model_paths(_examples_path)
+
+def get_expected_namefiles(path, pattern="mfsim.nam") -> List[Path]:
+    folders = []
+    for root, dirs, files in os.walk(path):
+        for d in dirs:
+            p = Path(root) / d
+            found = list(p.glob(pattern))
+            folders = folders + found
+    return sorted(list(set(folders)))
+
+
+@pytest.mark.skipif(
+    not any(_example_paths), reason="modflow6-examples repo not found"
+)
+def test_get_model_dir_paths_examples():
+    expected_paths = get_expected_model_dirs(_examples_path)
+    paths = get_model_dir_paths(_examples_path)
+    assert paths == sorted(list(set(paths)))  # no duplicates
     assert set(expected_paths) == set(paths)
 
-    expected_paths = get_expected(_examples_path, "*.nam")
-    paths = get_model_paths(_examples_path, namefile="*.nam")
+    expected_paths = get_expected_model_dirs(_examples_path, "*.nam")
+    paths = get_model_dir_paths(_examples_path, namefile="*.nam")
+    assert paths == sorted(list(set(paths)))
     assert set(expected_paths) == set(paths)
 
 
-@pytest.mark.skipif(not any(_example_paths), reason="examples not found")
-def test_get_model_paths_exclude_patterns():
-    paths = get_model_paths(_examples_path, excluded=["gwt"])
-    assert len(paths) == 63
+@pytest.mark.skipif(
+    not any(_largetestmodel_paths), reason="modflow6-largetestmodels not found"
+)
+def test_get_model_dir_paths_largetestmodels():
+    expected_paths = get_expected_model_dirs(_examples_path)
+    paths = get_model_dir_paths(_examples_path)
+    assert paths == sorted(list(set(paths)))
+    assert set(expected_paths) == set(paths)
+
+    expected_paths = get_expected_model_dirs(_examples_path)
+    paths = get_model_dir_paths(_examples_path)
+    assert paths == sorted(list(set(paths)))
+    assert set(expected_paths) == set(paths)
+
+
+@pytest.mark.skipif(
+    not any(_largetestmodel_paths) or not any(_example_paths),
+    reason="repos not found",
+)
+@pytest.mark.parametrize(
+    "models", [(_examples_path, 63), (_largetestmodels_repo_path, 15)]
+)
+def test_get_model_dir_paths_exclude_patterns(models):
+    path, expected_count = models
+    paths = get_model_dir_paths(path, excluded=["gwt"])
+    assert len(paths) == expected_count
+
+
+@pytest.mark.skipif(
+    not any(_example_paths), reason="modflow6-examples repo not found"
+)
+def test_get_namefile_paths_examples():
+    expected_paths = get_expected_namefiles(_examples_path)
+    paths = get_namefile_paths(_examples_path)
+    assert paths == sorted(list(set(paths)))
+    assert set(expected_paths) == set(paths)
+
+    expected_paths = get_expected_namefiles(_examples_path, "*.nam")
+    paths = get_namefile_paths(_examples_path, namefile="*.nam")
+    assert paths == sorted(list(set(paths)))
+    assert set(expected_paths) == set(paths)
+
+
+@pytest.mark.skipif(
+    not any(_largetestmodel_paths), reason="modflow6-largetestmodels not found"
+)
+def test_get_namefile_paths_largetestmodels():
+    expected_paths = get_expected_namefiles(_largetestmodels_repo_path)
+    paths = get_namefile_paths(_largetestmodels_repo_path)
+    assert paths == sorted(list(set(paths)))
+    assert set(expected_paths) == set(paths)
+
+    expected_paths = get_expected_namefiles(_largetestmodels_repo_path)
+    paths = get_namefile_paths(_largetestmodels_repo_path)
+    assert paths == sorted(list(set(paths)))
+    assert set(expected_paths) == set(paths)
+
+
+@pytest.mark.skipif(
+    not any(_largetestmodel_paths) or not any(_example_paths),
+    reason="repos not found",
+)
+@pytest.mark.parametrize(
+    "models", [(_examples_path, 43), (_largetestmodels_repo_path, 18)]
+)
+def test_get_namefile_paths_exclude_patterns(models):
+    path, expected_count = models
+    paths = get_namefile_paths(path, excluded=["gwf"])
+    assert len(paths) == expected_count
 
 
 @pytest.mark.skipif(not any(_example_paths), reason="examples not found")
-def test_get_model_paths_select_prefix():
-    paths = get_model_paths(_examples_path, prefix="ex2")
+def test_get_namefile_paths_select_prefix():
+    paths = get_namefile_paths(_examples_path, prefix="ex2")
     assert not any(paths)
 
+    paths = get_namefile_paths(_examples_path, prefix="ex")
+    assert any(paths)
+
 
 @pytest.mark.skipif(not any(_example_paths), reason="examples not found")
-def test_get_model_paths_select_patterns():
-    paths = get_model_paths(_examples_path, selected=["gwf"])
+def test_get_namefile_paths_select_patterns():
+    paths = get_namefile_paths(_examples_path, selected=["gwf"])
     assert len(paths) == 70
 
 
 @pytest.mark.skipif(not any(_example_paths), reason="examples not found")
-def test_get_model_paths_select_packages():
-    paths = get_model_paths(_examples_path, namefile="*.nam", packages=["wel"])
+def test_get_namefile_paths_select_packages():
+    paths = get_namefile_paths(
+        _examples_path, namefile="*.nam", packages=["wel"]
+    )
     assert len(paths) == 64


### PR DESCRIPTION
* refactor model-loading fixtures as `Path` to namefile rather than model directory, affects the following fixtures
  * `test_model_mf6`
  * `test_model_mf5to6`
  * `large_test_model`
* split `get_model_paths()` utility function into
  * `get_model_dir_paths()`
  * `get_namefile_paths()`
* add/update tests

This PR introduces a breaking change for model-loading fixtures. Previously the fixtures were `Path`s to the model directory, i.e. the folder containing the model's namefile. This caused ambiguity and/or duplication if a folder contained multiple namefiles. Since namefiles contain relative paths to inputs, it should be sufficient to provide the namefile path alone to test functions.

This PR does not change the `example_scenario` fixture, which is still a `Tuple[str, List[Path]]` mapping scenario name to ordered list of namefile paths.