### PR TITLE
docs(package): fix package development status

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ license_files = LICENSE.md
 platform = Windows, Mac OS-X, Linux
 keywords = MODFLOW, development
 classifiers =
-    Development Status :: 5 - Production/Stable
+    Development Status :: 3 - Alpha
     Intended Audience :: Science/Research
     License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
     Operating System :: Microsoft :: Windows


### PR DESCRIPTION
The development status was incorrectly set to `Production/Stable` but should reflect the project's early/pre-release state