### PR TITLE
fix(release): fix changelog commit links

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,43 +2,43 @@
 
 #### Refactoring
 
-* [refactor(fixtures)](https://github.com/modflowpy/flopy/commit/23593df7fb427d6de1d33f9aa408697d2536e473): Fix/refactor model-loading fixtures (#33). Committed by w-bonelli on 2022-12-29.
+* [refactor(fixtures)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/23593df7fb427d6de1d33f9aa408697d2536e473): Fix/refactor model-loading fixtures (#33). Committed by w-bonelli on 2022-12-29.
 
 ### Version 0.0.8
 
 #### Bug fixes
 
-* [fix(release)](https://github.com/modflowpy/flopy/commit/b62547bd607f9a0d3a78be61d16976bf406151f5): Exclude intermediate changelog (#28). Committed by w-bonelli on 2022-12-28.
-* [fix(fixtures)](https://github.com/modflowpy/flopy/commit/a2d4b9210db532f12cf87ae5d26582d1ed446463): Fix example_scenario fixture loading (#30). Committed by w-bonelli on 2022-12-29.
+* [fix(release)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/b62547bd607f9a0d3a78be61d16976bf406151f5): Exclude intermediate changelog (#28). Committed by w-bonelli on 2022-12-28.
+* [fix(fixtures)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/a2d4b9210db532f12cf87ae5d26582d1ed446463): Fix example_scenario fixture loading (#30). Committed by w-bonelli on 2022-12-29.
 
 ### Version 0.0.7
 
 #### Refactoring
 
-* [refactor(executables)](https://github.com/modflowpy/flopy/commit/58c3642d0e6d20d5e34783b5b61e8238058e102f): Simplify exes container, allow dict access (#24). Committed by w-bonelli on 2022-12-28.
-* [refactor](https://github.com/modflowpy/flopy/commit/50c83a9eaed532722549a2d9da1eb79ed8cf01be): Drop Python 3.7, add Python 3.11 (#25). Committed by w-bonelli on 2022-12-28.
+* [refactor(executables)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/58c3642d0e6d20d5e34783b5b61e8238058e102f): Simplify exes container, allow dict access (#24). Committed by w-bonelli on 2022-12-28.
+* [refactor](https://github.com/MODFLOW-USGS/modflow-devtools/commit/50c83a9eaed532722549a2d9da1eb79ed8cf01be): Drop Python 3.7, add Python 3.11 (#25). Committed by w-bonelli on 2022-12-28.
 
 ### Version 0.0.6
 
 #### New features
 
-* [feat(build)](https://github.com/modflowpy/flopy/commit/3108c380f29424bcdd1643479f66e849f7f762eb): Restore meson_build function (#15). Committed by w-bonelli on 2022-11-14.
+* [feat(build)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/3108c380f29424bcdd1643479f66e849f7f762eb): Restore meson_build function (#15). Committed by w-bonelli on 2022-11-14.
 
 #### Bug fixes
 
-* [fix](https://github.com/modflowpy/flopy/commit/933c79741b0e6a6db7c827414ebf635e62445772): Changes to support running of existing tests (#6). Committed by mjreno on 2022-07-20.
-* [fix(ci)](https://github.com/modflowpy/flopy/commit/0bb31907200be32bf2a045d54131f0a1dbd0ae2f): Don't build/test examples on python 3.7 (xmipy requires 3.8+) (#10). Committed by w-bonelli on 2022-11-08.
-* [fix(tests)](https://github.com/modflowpy/flopy/commit/3c63aaae581d335b1111b8dd2b929004b3281980): Mark test_download_and_unzip flaky (#11). Committed by w-bonelli on 2022-11-08.
-* [fix(fixtures)](https://github.com/modflowpy/flopy/commit/1e5fabdeb6d431f960316b049d68c4919650888c): Fix model-loading fixtures and utilities (#12). Committed by w-bonelli on 2022-11-11.
-* [fix(misc)](https://github.com/modflowpy/flopy/commit/80b8d1e1549676debda09383f75db50f5f11417a): Fix multiple issues (#16). Committed by w-bonelli on 2022-11-19.
-* [fix(auth)](https://github.com/modflowpy/flopy/commit/89db96ff5fb6e080c189f3a3e348ddf2ded21212): Fix GH API auth token in download_and_unzip (#17). Committed by w-bonelli on 2022-11-19.
-* [fix(download)](https://github.com/modflowpy/flopy/commit/58dff9f6c1245b22e3dc10411862d6eacea42e94): Use 'wb' instead of 'ab' mode when writing downloaded files, add retries (#20). Committed by w-bonelli on 2022-12-01.
+* [fix](https://github.com/MODFLOW-USGS/modflow-devtools/commit/933c79741b0e6a6db7c827414ebf635e62445772): Changes to support running of existing tests (#6). Committed by mjreno on 2022-07-20.
+* [fix(ci)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/0bb31907200be32bf2a045d54131f0a1dbd0ae2f): Don't build/test examples on python 3.7 (xmipy requires 3.8+) (#10). Committed by w-bonelli on 2022-11-08.
+* [fix(tests)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/3c63aaae581d335b1111b8dd2b929004b3281980): Mark test_download_and_unzip flaky (#11). Committed by w-bonelli on 2022-11-08.
+* [fix(fixtures)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/1e5fabdeb6d431f960316b049d68c4919650888c): Fix model-loading fixtures and utilities (#12). Committed by w-bonelli on 2022-11-11.
+* [fix(misc)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/80b8d1e1549676debda09383f75db50f5f11417a): Fix multiple issues (#16). Committed by w-bonelli on 2022-11-19.
+* [fix(auth)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/89db96ff5fb6e080c189f3a3e348ddf2ded21212): Fix GH API auth token in download_and_unzip (#17). Committed by w-bonelli on 2022-11-19.
+* [fix(download)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/58dff9f6c1245b22e3dc10411862d6eacea42e94): Use 'wb' instead of 'ab' mode when writing downloaded files, add retries (#20). Committed by w-bonelli on 2022-12-01.
 
 #### Refactoring
 
-* [refactor](https://github.com/modflowpy/flopy/commit/5aff3427351a0bbe38927d81dad42dd5374b67be): Updates to support modflow6 autotest and remove data path. Committed by mjreno on 2022-08-05.
-* [refactor](https://github.com/modflowpy/flopy/commit/e9e14f959e2a2ea016114c2dbfc35555b81459aa): Updates to support modflow6 autotest and remove data path. Committed by mjreno on 2022-08-05.
-* [refactor(ci)](https://github.com/modflowpy/flopy/commit/eefb659bb04df6aa18432165850a512285812d15): Create release and publish to PyPI when tags pushed (#14). Committed by w-bonelli on 2022-11-14.
-* [refactor(misc)](https://github.com/modflowpy/flopy/commit/1672733df1c17b802f1ade7d28db7bdb90496714): Refactor gh api & other http utilities (#18). Committed by w-bonelli on 2022-11-26.
-* [refactor](https://github.com/modflowpy/flopy/commit/bb8fa593cd21f2c0e8e9f3a6c2125fc22d5d9858): Remove mf6 file parsing fns (moved to flopy) (#19). Committed by w-bonelli on 2022-11-28.
+* [refactor](https://github.com/MODFLOW-USGS/modflow-devtools/commit/5aff3427351a0bbe38927d81dad42dd5374b67be): Updates to support modflow6 autotest and remove data path. Committed by mjreno on 2022-08-05.
+* [refactor](https://github.com/MODFLOW-USGS/modflow-devtools/commit/e9e14f959e2a2ea016114c2dbfc35555b81459aa): Updates to support modflow6 autotest and remove data path. Committed by mjreno on 2022-08-05.
+* [refactor(ci)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/eefb659bb04df6aa18432165850a512285812d15): Create release and publish to PyPI when tags pushed (#14). Committed by w-bonelli on 2022-11-14.
+* [refactor(misc)](https://github.com/MODFLOW-USGS/modflow-devtools/commit/1672733df1c17b802f1ade7d28db7bdb90496714): Refactor gh api & other http utilities (#18). Committed by w-bonelli on 2022-11-26.
+* [refactor](https://github.com/MODFLOW-USGS/modflow-devtools/commit/bb8fa593cd21f2c0e8e9f3a6c2125fc22d5d9858): Remove mf6 file parsing fns (moved to modflow-devtools) (#19). Committed by w-bonelli on 2022-11-28.
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -10,7 +10,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     #### {{ group | upper_first }}
     {% for commit in commits %}
-        * [{{ commit.group }}{% if commit.scope %}({{ commit.scope }}){% endif %}](https://github.com/modflowpy/flopy/commit/{{ commit.id }}): {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}. Committed by {{ commit.author.name }} on {{ commit.author.timestamp | date(format="%Y-%m-%d") }}.\
+        * [{{ commit.group }}{% if commit.scope %}({{ commit.scope }}){% endif %}](https://github.com/MODFLOW-USGS/modflow-devtools/commit/{{ commit.id }}): {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}. Committed by {{ commit.author.name }} on {{ commit.author.timestamp | date(format="%Y-%m-%d") }}.\
     {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
Commit links in `HISTORY.md` (and associated config in `cliff.toml`) mistakenly referred to the `modflowpy/flopy` repo, fix them