### PR TITLE
refactor(utilities): restore get_model_paths function name

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,26 +6,22 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = 'modflow-devtools'
-author = 'MODFLOW Team'
-release = '0.1.1'
+project = "modflow-devtools"
+author = "MODFLOW Team"
+release = "0.1.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['myst_parser']
-source_suffix = {
-    '.rst': 'restructuredtext',
-    '.md': 'markdown'
-}
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
+extensions = ["myst_parser"]
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'sphinx_rtd_theme'
-html_title = 'MODFLOW Devtools'
-html_static_path = ['_static']
+html_theme = "sphinx_rtd_theme"
+html_title = "MODFLOW Devtools"
+html_static_path = ["_static"]

--- a/docs/md/fixtures.md
+++ b/docs/md/fixtures.md
@@ -94,7 +94,7 @@ def test_example_scenario(tmp_path, example_scenario):
 
 Model-loading fixtures use a set of utility functions to find and enumerate models. These functions can be imported from `modflow_devtools.misc` for use in other contexts:
 
-- `get_model_dir_paths()`
+- `get_model_paths()`
 - `get_namefile_paths()`
 
 See this project's test suite for usage examples.

--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 
 import pytest
 from modflow_devtools.misc import (
-    get_model_dir_paths,
+    get_model_paths,
     get_namefile_paths,
     get_packages,
 )

--- a/modflow_devtools/misc.py
+++ b/modflow_devtools/misc.py
@@ -219,7 +219,7 @@ def get_namefile_paths(
     return sorted(paths)
 
 
-def get_model_dir_paths(
+def get_model_paths(
     path: PathLike,
     prefix: str = None,
     namefile: str = "mfsim.nam",

--- a/modflow_devtools/test/test_misc.py
+++ b/modflow_devtools/test/test_misc.py
@@ -5,7 +5,7 @@ from typing import List
 
 import pytest
 from modflow_devtools.misc import (
-    get_model_dir_paths,
+    get_model_paths,
     get_namefile_paths,
     get_packages,
     set_dir,
@@ -61,14 +61,14 @@ def get_expected_namefiles(path, pattern="mfsim.nam") -> List[Path]:
 @pytest.mark.skipif(
     not any(_example_paths), reason="modflow6-examples repo not found"
 )
-def test_get_model_dir_paths_examples():
+def test_get_model_paths_examples():
     expected_paths = get_expected_model_dirs(_examples_path)
-    paths = get_model_dir_paths(_examples_path)
+    paths = get_model_paths(_examples_path)
     assert paths == sorted(list(set(paths)))  # no duplicates
     assert set(expected_paths) == set(paths)
 
     expected_paths = get_expected_model_dirs(_examples_path, "*.nam")
-    paths = get_model_dir_paths(_examples_path, namefile="*.nam")
+    paths = get_model_paths(_examples_path, namefile="*.nam")
     assert paths == sorted(list(set(paths)))
     assert set(expected_paths) == set(paths)
 
@@ -76,14 +76,14 @@ def test_get_model_dir_paths_examples():
 @pytest.mark.skipif(
     not any(_largetestmodel_paths), reason="modflow6-largetestmodels not found"
 )
-def test_get_model_dir_paths_largetestmodels():
+def test_get_model_paths_largetestmodels():
     expected_paths = get_expected_model_dirs(_examples_path)
-    paths = get_model_dir_paths(_examples_path)
+    paths = get_model_paths(_examples_path)
     assert paths == sorted(list(set(paths)))
     assert set(expected_paths) == set(paths)
 
     expected_paths = get_expected_model_dirs(_examples_path)
-    paths = get_model_dir_paths(_examples_path)
+    paths = get_model_paths(_examples_path)
     assert paths == sorted(list(set(paths)))
     assert set(expected_paths) == set(paths)
 
@@ -95,9 +95,9 @@ def test_get_model_dir_paths_largetestmodels():
 @pytest.mark.parametrize(
     "models", [(_examples_path, 63), (_largetestmodels_repo_path, 15)]
 )
-def test_get_model_dir_paths_exclude_patterns(models):
+def test_get_model_paths_exclude_patterns(models):
     path, expected_count = models
-    paths = get_model_dir_paths(path, excluded=["gwt"])
+    paths = get_model_paths(path, excluded=["gwt"])
     assert len(paths) == expected_count
 
 


### PR DESCRIPTION
Revert the naming change in 0.1.0 from `get_model_paths()` -> `get_model_dir_paths()`. The former is more concise anyway and this avoids breaking downstream usages (e.g. [the nightly build](https://github.com/MODFLOW-USGS/modflow6-nightly-build/actions/runs/3804393985/jobs/6471976509)).