### PR TITLE
docs: update/expand docs, fix TOC in DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -5,12 +5,14 @@ This document provides guidance to set up a development environment and discusse
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Testing](#testing)
   - [Environment variables](#environment-variables)
   - [Running the tests](#running-the-tests)
   - [Writing new tests](#writing-new-tests)
     - [Temporary directories](#temporary-directories)
+- [Releasing](#releasing)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/docs/md/cases.md
+++ b/docs/md/cases.md
@@ -1,8 +1,8 @@
 # Cases
 
-An alternative approach to testing, rather than loading pre-existing models from a repository, is to construct test models in code. This typically involves defining variables or `pytest` fixtures in the same test script as the test function. While this pattern is effective for manually defined scenarios, it tightly couples test functions to test cases, prevents easy reuse of the test case by other tests, and tends to lead to duplication, as each test script may reproduce similar test functions and data-generation procedures.
+Constructing test models in code typically involves defining variables or `pytest` fixtures in the same test script as the test function. While this is quick and effective for manually defining new scenarios, it tightly couples test functions to test cases, makes reuse of the test case by other tests more difficult, and tends to lead to duplication, as test scripts may reproduce similar testing and data-generating procedures.
 
-This package provides a minimal framework for self-describing test cases which can be defined once and plugged into arbitrary test functions. At its core is the `Case` class, which is just a `SimpleNamespace` with a few defaults and a `copy_update()` method for easy modification. This pairs nicely with [`pytest-cases`](https://smarie.github.io/python-pytest-cases/), which is recommended but not required.
+A minimal framework is provided for self-describing test cases which can be plugged into arbitrary test functions. At its core is the `Case` class, which is just a `SimpleNamespace` with a few defaults and a `copy_update()` method. This pairs nicely with [`pytest-cases`](https://smarie.github.io/python-pytest-cases/), which is recommended but not required.
 
 ## Overview
 

--- a/docs/md/install.md
+++ b/docs/md/install.md
@@ -28,5 +28,5 @@ pip install ".[lint, test, docs]"
 Fixtures provided by `modflow-devtools` can be imported into a `pytest` test suite by adding the following to the consuming project's top-level `conftest.py` file:
 
 ```python
-pytest_plugins = ["modflow_devtools"]
+pytest_plugins = ["modflow_devtools.fixtures"]
 ```


### PR DESCRIPTION
- clarify usage examples for `Executables`
- mention function to create default `Executables` config for modflow6 testing
- simplify `Case` docs wording
- fix instructions for importing as pytest plugin (trailing `.fixtures` was missing)
- fix TOC in `DEVELOPER.md`