### PR TITLE
refactor(fixtures): add default external model repo location

### DIFF
--- a/docs/md/act.md
+++ b/docs/md/act.md
@@ -1,6 +1,8 @@
-# Local CI testing
+# Testing CI workflows locally
 
-The [`act`](https://github.com/nektos/act) tool uses Docker to run containerized CI workflows in a simulated GitHub Actions environment. [Docker Desktop](https://www.docker.com/products/docker-desktop/) is required for Mac or Windows and [Docker Engine](https://docs.docker.com/engine/) on Linux.
+The [`act`](https://github.com/nektos/act) tool uses Docker to run CI workflows in a simulated GitHub Actions environment. [Docker Desktop](https://www.docker.com/products/docker-desktop/) is required for Mac or Windows and [Docker Engine](https://docs.docker.com/engine/) on Linux.
+
+**Note:** `act` can only run Linux-based container definitions. Mac or Windows workflows or matrix OS entries will be skipped.
 
 With Docker installed and running, run `act -l` from the project root to see available CI workflows. To run all workflows and jobs, just run `act`. To run a particular workflow use `-W`:
 
@@ -17,5 +19,3 @@ act -W .github/workflows/commit.yml -j build
 **Note:** GitHub API rate limits are easy to exceed, especially with job matrices. Authenticated GitHub users have a much higher rate limit: use `-s GITHUB_TOKEN=<your token>` when invoking `act` to provide a personal access token. Note that this will log your token in shell history &mdash; leave the value blank for a prompt to enter it more securely.
 
 The `-n` flag can be used to execute a dry run, which doesn't run anything, just evaluates workflow, job and step definitions. See the [docs](https://github.com/nektos/act#example-commands) for more.
-
-**Note:** `act` can only run Linux-based container definitions, so Mac or Windows workflows or matrix OS entries will be skipped.

--- a/docs/md/fixtures.md
+++ b/docs/md/fixtures.md
@@ -55,9 +55,7 @@ These models can be requested like any other `pytest` fixture, by adding one of 
 - `large_test_model`
 - `example_scenario`
 
-To use these fixtures, the environment variable `REPOS_PATH` must point to the location of model repositories on the filesystem. Model repositories must live side-by-side in this location, and repository directories are expected to be named identically to GitHub repositories. If `REPOS_PATH` is not configured, test functions requesting these fixtures will be skipped.
-
-**Note**: example models must be built by running the `ci_build_files.py` script in `modflow6-examples/etc` before running tests using the `example_scenario` fixture.
+It is recommended to set the environment variable `REPOS_PATH` to the location of the model repositories on the filesystem. Model repositories must live side-by-side in this location, and repository directories are expected to be named identically to GitHub repositories. If `REPOS_PATH` is not configured, `modflow-devtools` assumes tests are being run from an `autotest` subdirectory of the consuming project's root, and model repos live side-by-side with the consuming project. If this guess is incorrect and repositories cannot be found, tests requesting these fixtures will be skipped.
 
 ### Test models
 
@@ -89,6 +87,8 @@ def test_example_scenario(tmp_path, example_scenario):
         # load and run model
         # ...
 ```
+
+**Note**: example models must be built by running the `ci_build_files.py` script in `modflow6-examples/etc` before running tests using the `example_scenario` fixture.
 
 ### Utility functions
 

--- a/docs/md/install.md
+++ b/docs/md/install.md
@@ -1,6 +1,6 @@
-# Installing `modflow-devtools`
+# Installation
 
-## Official package
+## Installing `modflow-devtools` from PyPI
 
 The `modflow-devtools` package is [available on PyPi](https://pypi.org/project/modflow-devtools/) and can be installed with `pip`:
 
@@ -8,7 +8,7 @@ The `modflow-devtools` package is [available on PyPi](https://pypi.org/project/m
 pip install modflow-devtools
 ```
 
-## Development version
+## Installing `modflow-devtools` from source
 
 To set up a `modflow-devtools` development environment, first clone the repository:
 
@@ -30,3 +30,47 @@ Fixtures provided by `modflow-devtools` can be imported into a `pytest` test sui
 ```python
 pytest_plugins = ["modflow_devtools.fixtures"]
 ```
+
+## Installing external model repositories
+
+`modflow-devtools` provides fixtures to load models from external repositories:
+
+- [`MODFLOW-USGS/modflow6-examples`](https://github.com/MODFLOW-USGS/modflow6-examples)
+- [`MODFLOW-USGS/modflow6-testmodels`](https://github.com/MODFLOW-USGS/modflow6-testmodels)
+- [`MODFLOW-USGS/modflow6-largetestmodels`](https://github.com/MODFLOW-USGS/modflow6-largetestmodels)
+
+By default, these fixtures expect model repositories to live next to (i.e. in the same parent directory as) the consuming project repository. If the repos are somewhere else, you can set the `REPOS_PATH` environment variable to point to their parent directory.
+
+**Note:** a convenient way to persist environment variables needed for tests is to store them in a `.env` file in the `autotest` folder. Each variable should be defined on a separate line, with format `KEY=VALUE`. The `pytest-dotenv` plugin will then automatically load any variables found in this file into the test process' environment.
+
+### Installing test models
+
+The test model repos can simply be cloned &mdash; ideally, into the parent directory of the `modflow6` repository, so that repositories live side-by-side:
+
+```shell
+git clone MODFLOW-USGS/modflow6-testmodels
+git clone MODFLOW-USGS/modflow6-largetestmodels
+```
+
+### Installing example models
+
+First clone the example models repo:
+
+```shell
+git clone MODFLOW-USGS/modflow6-examples
+```
+
+The example models require some setup after cloning. Some extra Python dependencies are required to build the examples: 
+
+```shell
+cd modflow6-examples/etc
+pip install -r requirements.pip.txt
+```
+
+Then, still from the `etc` folder, run:
+
+```shell
+python ci_build_files.py
+```
+
+This will build the examples for subsequent use by the tests.

--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -170,6 +170,11 @@ def pytest_generate_tests(metafunc):
     models_selected = metafunc.config.getoption("--model", None)
     packages_selected = metafunc.config.getoption("--package", None)
     repos_path = environ.get("REPOS_PATH")
+    if repos_path is None:
+        # by default, assume external repositories are
+        # in the same directory as the current project
+        # and tests are run from <proj root>/autotest.
+        repos_path = Path.cwd().parent.parent
 
     key = "test_model_mf6"
     if key in metafunc.fixturenames:

--- a/modflow_devtools/test/test_build.py
+++ b/modflow_devtools/test/test_build.py
@@ -6,7 +6,10 @@ import pytest
 from modflow_devtools.build import meson_build
 from modflow_devtools.markers import requires_pkg
 
-_repos_path = Path(environ.get("REPOS_PATH")).expanduser().absolute()
+_repos_path = environ.get("REPOS_PATH")
+if _repos_path is None:
+    _repos_path = Path(__file__).parent.parent.parent.parent
+_repos_path = Path(_repos_path).expanduser().absolute()
 _project_root_path = Path(__file__).parent.parent.parent.parent
 _modflow6_repo_path = _repos_path / "modflow6"
 _system = platform.system()

--- a/modflow_devtools/test/test_fixtures.py
+++ b/modflow_devtools/test/test_fixtures.py
@@ -263,4 +263,4 @@ def test_large_test_model(large_test_model):
     print(large_test_model)
     assert isinstance(large_test_model, Path)
     assert large_test_model.is_file()
-    assert large_test_model.suffix == ".nam"
+    assert large_test_model.name == "mfsim.nam"

--- a/modflow_devtools/test/test_misc.py
+++ b/modflow_devtools/test/test_misc.py
@@ -20,7 +20,10 @@ def test_set_dir(tmp_path):
     assert Path(os.getcwd()) != tmp_path
 
 
-_repos_path = Path(environ.get("REPOS_PATH")).expanduser().absolute()
+_repos_path = environ.get("REPOS_PATH")
+if _repos_path is None:
+    _repos_path = Path(__file__).parent.parent.parent.parent
+_repos_path = Path(_repos_path).expanduser().absolute()
 _largetestmodels_repo_path = _repos_path / "modflow6-largetestmodels"
 _largetestmodel_paths = sorted(list(_largetestmodels_repo_path.glob("test*")))
 _examples_repo_path = _repos_path / "modflow6-examples"


### PR DESCRIPTION
- Search for model repos in a default location relative to the working directory. If the consuming project's tests are run from an `autotest` folder in the project root, and model repos live next to the consuming project, models will be found by fixtures. This makes model-finding fixtures usable without setting the  `REPOS_PATH` environment variable, which was previously required.
- Don't skip any models by default when loading via fixtures. Consuming projects can `pytest.skip()` in the test function or use `get_model_paths()` or `get_namefile_paths()` directly if more control is required over which models are loaded.
- Expand/clarify documentation