### PR TITLE
refactor(fixtures): overwrite keepable temp dirs by default

### DIFF
--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from itertools import groupby
 from os import PathLike, environ
 from pathlib import Path
-from shutil import copytree
+from shutil import copytree, rmtree
 from typing import Dict, List, Optional
 
 import pytest
@@ -23,11 +23,17 @@ def function_tmpdir(tmpdir_factory, request) -> Path:
 
     keep = request.config.getoption("--keep")
     if keep:
-        copytree(temp, Path(keep) / temp.name)
+        path = Path(keep) / temp.name
+        if path.is_dir():
+            rmtree(path)
+        copytree(temp, path)
 
     keep_failed = request.config.getoption("--keep-failed")
     if keep_failed and request.node.rep_call.failed:
-        copytree(temp, Path(keep_failed) / temp.name)
+        path = Path(keep_failed) / temp.name
+        if path.is_dir():
+            rmtree(path)
+        copytree(temp, path)
 
 
 @pytest.fixture(scope="class")
@@ -40,7 +46,10 @@ def class_tmpdir(tmpdir_factory, request) -> Path:
 
     keep = request.config.getoption("--keep")
     if keep:
-        copytree(temp, Path(keep) / temp.name)
+        path = Path(keep) / temp.name
+        if path.is_dir():
+            rmtree(path)
+        copytree(temp, path)
 
 
 @pytest.fixture(scope="module")
@@ -50,8 +59,10 @@ def module_tmpdir(tmpdir_factory, request) -> Path:
 
     keep = request.config.getoption("--keep")
     if keep:
-        copytree(temp, Path(keep) / temp.name)
-        print(list((Path(keep) / temp.name).rglob("*")))
+        path = Path(keep) / temp.name
+        if path.is_dir():
+            rmtree(path)
+        copytree(temp, path)
 
 
 @pytest.fixture(scope="session")
@@ -61,7 +72,10 @@ def session_tmpdir(tmpdir_factory, request) -> Path:
 
     keep = request.config.getoption("--keep")
     if keep:
-        copytree(temp, Path(keep) / temp.name)
+        path = Path(keep) / temp.name
+        if path.is_dir():
+            rmtree(path)
+        copytree(temp, path)
 
 
 # environment-dependent fixtures

--- a/modflow_devtools/test/test_fixtures.py
+++ b/modflow_devtools/test/test_fixtures.py
@@ -105,6 +105,7 @@ def test_keep_session_scoped_tmpdir_inner(session_tmpdir):
 @pytest.mark.parametrize("arg", ["--keep", "-K"])
 def test_keep_function_scoped_tmpdir(function_tmpdir, arg):
     inner_fn = test_keep_function_scoped_tmpdir_inner.__name__
+    file_path = Path(function_tmpdir / f"{inner_fn}0" / FILE_NAME)
     args = [
         __file__,
         "-v",
@@ -117,7 +118,15 @@ def test_keep_function_scoped_tmpdir(function_tmpdir, arg):
         function_tmpdir,
     ]
     assert pytest.main(args) == ExitCode.OK
-    assert Path(function_tmpdir / f"{inner_fn}0" / FILE_NAME).is_file()
+    assert file_path.is_file()
+    first_modified = file_path.stat().st_mtime
+
+    assert pytest.main(args) == ExitCode.OK
+    assert file_path.is_file()
+    second_modified = file_path.stat().st_mtime
+
+    # make sure contents were overwritten
+    assert first_modified < second_modified
 
 
 @pytest.mark.parametrize("arg", ["--keep", "-K"])


### PR DESCRIPTION
Previously, keepable temporary directory fixtures did not overwrite existing folders. Needing to manually remove temp folders increases friction for repeated testing/debugging, so this PR updates the `--keep` option to overwrite the specified location.

While this introduces the potential for data loss, presumably users of this package are running tests from an `autotest` folder, which shouldn't contain anything valuable that's not already under version control.