### PR TITLE
docs: update/clarify various rtd pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This package contains shared tools for developing and testing MODFLOW 6 and FloP
 
 ## Quickstart
 
-To import `pytest` fixtures in a project consuming `modflow-devtools`, add the following to a `conftest.py` file in the project root:
+To import `pytest` fixtures in a project consuming `modflow-devtools`, add the following to a `conftest.py` file:
 
 ```python
 pytest_plugins = [ "modflow_devtools.fixtures" ]

--- a/docs/md/cases.md
+++ b/docs/md/cases.md
@@ -2,7 +2,7 @@
 
 Constructing test models in code typically involves defining variables or `pytest` fixtures in the same test script as the test function. While this is quick and effective for manually defining new scenarios, it tightly couples test functions to test cases, makes reuse of the test case by other tests more difficult, and tends to lead to duplication, as test scripts may reproduce similar testing and data-generating procedures.
 
-A minimal framework is provided for self-describing test cases which can be plugged into arbitrary test functions. At its core is the `Case` class, which is just a `SimpleNamespace` with a few defaults and a `copy_update()` method. This pairs nicely with [`pytest-cases`](https://smarie.github.io/python-pytest-cases/), which is recommended but not required.
+A minimal framework is provided for self-describing test cases which can be plugged into arbitrary test functions. At its core is the `Case` class, which is just a `SimpleNamespace` with a few defaults and a `copy_update()` method. This pairs nicely with [`pytest-cases`](https://smarie.github.io/python-pytest-cases/).
 
 ## Overview
 

--- a/docs/md/download.md
+++ b/docs/md/download.md
@@ -2,11 +2,11 @@
 
 Some utility functions are provided to query information and download artifacts and assets from the GitHub API. These are available in the `modflow_devtools.download` module and are briefly described below. See this project's test cases (in particular `test_download.py`) for more usage examples.
 
-**Note:** to avoid GitHub API rate limits when using these functions, it is recommended to set the `GITHUB_TOKEN` environment variable. If this variable is set, the token will automatically be borne on requests sent to the API.
+**Note:** to avoid GitHub API rate limits when using these functions, it is recommended to set the `GITHUB_TOKEN` environment variable. If this variable is set, the token will be borne on requests sent to the API.
 
 ## Retrieving information
 
-The following functions ask the GitHub API for information about a repository. The singular functions return a dictionary, while the plural functions return a list of dictionaries, with dictionary contents parsed directly from the API response's JSON.
+The following functions ask the GitHub API for information about a repository. The singular functions generally return a dictionary, while the plural functions return a list of dictionaries, with dictionary contents parsed directly from the API response's JSON.
 
 - `get_releases(repo, per_page=30, max_pages=10, retries=3, verbose=False)`
 - `get_release(repo, tag="latest", retries=3, verbose=False)`
@@ -60,11 +60,11 @@ The `download_artifact(repo, id, path=None, delete_zip=True, verbose=False)` fun
 
 The `download_and_unzip(url, path=None, delete_zip=True, verbose=False)` function is a more generic alternative for downloading and unzipping files from arbitrary URLs.
 
-For instance, to download a MODFLOW 6.3.0 Linux distribution and delete the zipfile after extracting:
+For instance, to download a MODFLOW 6.4.1 Linux distribution and delete the zipfile after extracting:
 
 ```python
 from modflow_devtools.download import download_and_unzip
 
-url = f"https://github.com/MODFLOW-USGS/modflow6/releases/download/6.3.0/mf6.3.0_linux.zip"
-download_and_unzip(url, "some/download/path", delete_zip=True, verbose=True)
+url = f"https://github.com/MODFLOW-USGS/modflow6/releases/download/6.4.1/mf6.4.1_linux.zip"
+download_and_unzip(url, "~/Downloads", delete_zip=True, verbose=True)
 ```

--- a/docs/md/executables.md
+++ b/docs/md/executables.md
@@ -4,61 +4,38 @@ The `Executables` class maps executable names to paths on the filesystem. This i
 
 ## Usage
 
-For example, assuming you have some development binaries in `bin` relative to your current working directory, and an official installation of the same programs in `~/.local.bin`:
-
-```python
-from pathlib import Path
-from modflow_devtools.executables import Executables
-
-bindir_path = Path("~/.local/bin").expanduser()
-executables = Executables(mf6=bindir_path / "mf6", mf6_dev=Path("mf6"))
-
-# constructor also supports kwargs
-executables = Executables(**{"mf6": bindir_path / "mf6", "mf6_dev": Path("mf6")})
-
-def test_executables():
-    assert executables.mf6.is_file()
-    assert executables.mf6_dev.is_file()
-
-    assert executables.mf6 == bindir_path / "mf6"
-    assert executables.mf6_dev == Path("mf6")
-```
-
-The class is easily injected into test functions as a fixture:
-
-```python
-import pytest
-
-@pytest.fixture
-@pytest.mark.skipif(not bindir_path.is_dir())
-def exes():
-    return executables
-```
-
-Dictionary-style access is also supported:
-
-```python
-def test_executables_access(executables):
-    assert executables["mf6"] == executables.mf6 == Path("mf6")
-```
-
-There is a convenience function for getting a program's version string. The function will automatically strip the program name from the output (assumed delimited with `:`).
-
-```python
-import subprocess
-
-def test_executables_version(exes):
-    # e.g. '6.4.1 Release 12/09/2022'
-    assert exes.get_version(exes.mf6) == \  
-           subprocess.check_output([f"{exes.mf6}", "-v"]).decode('utf-8').strip().split(":")[1].strip()
-```
-
-## Default mapping
-
-A utility function is provided to create the default executable mapping used by MODFLOW 6 autotests:
+For example, assuming development binaries live in `bin` relative to the project root (as is currently the convention for `modflow6`), the following `pytest` fixtures could be defined:
 
 ```python
 from modflow_devtools.executables import build_default_exe_dict, Executables
 
-exes = Executables(**build_default_exe_dict())
+@pytest.fixture(scope="session")
+def bin_path() -> Path:
+    return project_root_path / "bin"
+
+
+@pytest.fixture(scope="session")
+def targets(bin_path) -> Executables:
+    return Executables(**build_default_exe_dict(bin_path))
+```
+
+The `targets` fixture can then be injected into test functions:
+
+```python
+def test_targets(targets):
+    # attribute- and dictionary-style access is supported
+    assert targets["mf6"] == targets.mf6
+```
+
+The `build_default_exe_dict` function is provided to create the default executable mapping used by MODFLOW 6 autotests.
+
+There is also a convenience function for getting a program's version string. The function will automatically strip the program name from the output (assumed delimited with `:`).
+
+```python
+import subprocess
+
+def test_executables_version(targets):
+    # returns e.g. '6.4.1 Release 12/09/2022'
+    assert targets.get_version(targets.mf6) == \  
+           subprocess.check_output([f"{targets.mf6}", "-v"]).decode('utf-8').strip().split(":")[1].strip()
 ```


### PR DESCRIPTION
Fix/clarify a few things in docs and README
- simplify some usage examples
- clarify some language describing temp dir fixtures
- to use devtools as a `pytest` plugin, `conftest.py` need not live in the consuming project's root