### PR TITLE
fix(multiple): fix CI and fixture issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         with:
           repository: MODFLOW-USGS/modflow6-largetestmodels
           path: modflow6-largetestmodels
+          token: ${{ github.token }}
 
       - name: Install executables
         uses: modflowpy/install-modflow-action@v1
@@ -160,10 +161,22 @@ jobs:
         working-directory: modflow6-examples/etc
         run: python ci_build_files.py
 
-      - name: Run tests
+      - name: Run local tests
         working-directory: modflow-devtools
         env:
           BIN_PATH: ~/.local/bin/modflow
           REPOS_PATH: ${{ github.workspace }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pytest -v -n auto --durations 0
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pytest -v -n auto --durations 0 --ignore modflow_devtools/test/test_download.py
+      
+      - name: Run network-dependent tests
+        # only invoke the GH API on one OS and Python version
+        # to avoid rate limits (1000 rqs / hour / repository)
+        # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
+        if: runner.os == 'Linux' && matrix.python == '3.8'
+        working-directory: modflow-devtools
+        env:
+          BIN_PATH: ~/.local/bin/modflow
+          REPOS_PATH: ${{ github.workspace }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pytest -v -n auto --durations 0 modflow_devtools/test/test_download.py

--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -309,7 +309,12 @@ def pytest_generate_tests(metafunc):
 
         def get_examples():
             # find MODFLOW 6 namfiles
-            namfiles = [p for p in (repo_path / "examples").rglob("mfsim.nam")]
+            examples_path = repo_path / "examples"
+            namfiles = (
+                [p for p in examples_path.rglob("mfsim.nam")]
+                if examples_path.is_dir()
+                else []
+            )
 
             # group by scenario
             examples = group_examples(namfiles)
@@ -352,7 +357,7 @@ def pytest_generate_tests(metafunc):
 
             return examples
 
-        example_scenarios = get_examples() if repo_path.is_dir() else dict()
+        example_scenarios = get_examples() if repo_path else dict()
         metafunc.parametrize(
             key,
             [(name, nfps) for name, nfps in example_scenarios.items()],

--- a/modflow_devtools/test/test_download.py
+++ b/modflow_devtools/test/test_download.py
@@ -69,7 +69,7 @@ def test_list_artifacts(tmp_path, name, per_page):
         "MODFLOW-USGS/modflow6",
         name=name,
         per_page=per_page,
-        max_pages=3,
+        max_pages=2,
         verbose=True,
     )
 


### PR DESCRIPTION
- Improve implementation of external model repo discovery from #80
- Only run network-dependent tests on a single job in CI testing, not the whole matrix. The [rate limit](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits) for CI is 1000 requests per hour per repo, which this repo likely hit due to parametrized tests for GH API utility functions.