### PR TITLE
refactor(download_and_unzip): return path to extract locn

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Python development tools for MODFLOW 6.
 
 This is a small toolkit for developing MODFLOW 6, FloPy, and related projects. It includes standalone utilities and optional [Pytest](https://github.com/pytest-dev/pytest) extensions.
 
-Standalone utilities include a very minimal GitHub API client, mainly for retrieving release information and downloading asset, and a `ZipFile` subclass that [preserves file permissions](https://stackoverflow.com/questions/39296101/python-zipfile-removes-execute-permissions-from-binaries) (workaround for [Python #15795](https://bugs.python.org/issue15795))
+Standalone utilities include a very minimal GitHub API client, mainly for retrieving release information and downloading assets, and a `ZipFile` subclass that [preserves file permissions](https://stackoverflow.com/questions/39296101/python-zipfile-removes-execute-permissions-from-binaries) (workaround for [Python #15795](https://bugs.python.org/issue15795))
 
 Pytest features include:
 

--- a/docs/md/download.md
+++ b/docs/md/download.md
@@ -77,3 +77,5 @@ from modflow_devtools.download import download_and_unzip
 url = f"https://github.com/MODFLOW-USGS/modflow6/releases/download/6.4.1/mf6.4.1_linux.zip"
 download_and_unzip(url, "~/Downloads", delete_zip=True, verbose=True)
 ```
+
+The function's return value is the `Path` the archive was extracted to.

--- a/modflow_devtools/download.py
+++ b/modflow_devtools/download.py
@@ -438,7 +438,7 @@ def download_and_unzip(
     delete_zip=True,
     retries=3,
     verbose=False,
-):
+) -> Path:
     """
     Download and unzip a zip file from a URL.
     The filename must be the last element in the URL.
@@ -455,6 +455,11 @@ def download_and_unzip(
         The maximum number of retries for each request
     verbose : bool
         Whether to show verbose output
+
+    Returns
+    -------
+    Path
+        The path to the directory where the zip file was unzipped
     """
 
     path = Path(path if path else os.getcwd())
@@ -544,3 +549,5 @@ def download_and_unzip(
 
     if verbose:
         print(f"Done downloading and extracting {file_path.name} to {path}")
+
+    return path


### PR DESCRIPTION
- convenient for e.g. downloading from URLs which don't correspond to downloaded filename and extract dir