### PR TITLE
refactor(has_pkg): introduce strict flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,8 @@ jobs:
           BIN_PATH: ~/.local/bin/modflow
           REPOS_PATH: ${{ github.workspace }}
           GITHUB_TOKEN: ${{ github.token }}
-        run: pytest -v -n auto --durations 0 --ignore modflow_devtools/test/test_download.py
+        # use --dist loadfile to so tests requiring pytest-virtualenv run on the same worker
+        run: pytest -v -n auto --dist loadfile --durations 0 --ignore modflow_devtools/test/test_download.py
       
       - name: Run network-dependent tests
         # only invoke the GH API on one OS and Python version

--- a/conftest.py
+++ b/conftest.py
@@ -1,1 +1,4 @@
+from pathlib import Path
+
 pytest_plugins = ["modflow_devtools.fixtures"]
+project_root_path = Path(__file__).parent

--- a/modflow_devtools/markers.py
+++ b/modflow_devtools/markers.py
@@ -22,7 +22,7 @@ def requires_exe(*exes):
 
 
 def requires_pkg(*pkgs):
-    missing = {pkg for pkg in pkgs if not has_pkg(pkg)}
+    missing = {pkg for pkg in pkgs if not has_pkg(pkg, strict=True)}
     return pytest.mark.skipif(
         missing,
         reason=f"missing package{'s' if len(missing) != 1 else ''}: "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ test = [
     "pytest-cases",
     "pytest-cov",
     "pytest-dotenv",
+    "pytest-virtualenv",
     "pytest-xdist",
     "PyYaml"
 ]


### PR DESCRIPTION
* add `strict` param to `has_pkg()` toggling whether to try to import the pkg or only check metadata
  * always invalidate/refresh the cache if strict is on
* add `pytest-virtualenv` to test dependencies, test with/without strict
  * use `--dist loadfile` with xdist in CI for compatibility
* motivated by https://github.com/modflowpy/flopy/pull/1918, tests marked with `requires_pkg` could fail if a pkg has been installed but is missing dependencies