### PR TITLE
docs: update deprecated config in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,13 @@
 version: 2
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
 sphinx:
   configuration: docs/conf.py
 formats:
   - pdf
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
- use `build.os` as recommended by https://blog.readthedocs.com/use-build-os-config/
- also move python version to `build.tools.python`