### PR TITLE
feat(fixtures): add --tabular pytest CLI arg and corresponding fixture

### DIFF
--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -101,6 +101,14 @@ def use_pandas(request):
         raise ValueError(f"Unsupported value for --pandas: {pandas}")
 
 
+@pytest.fixture
+def tabular(request):
+    tab = request.config.option.TABULAR
+    if tab not in ["raw", "recarray", "dataframe"]:
+        raise ValueError(f"Unsupported value for --tabular: {tab}")
+    return tab
+
+
 # configuration hooks
 
 
@@ -163,7 +171,16 @@ def pytest_addoption(parser):
         action="store",
         default="yes",
         dest="PANDAS",
-        help="Package input data can be provided as either pandas dataframes or numpy recarrays. By default, pandas dataframes are used. To test with numpy recarrays, use 'no'. To randomize selection (per test), use 'random'.",
+        help="Indicates whether to use pandas, where multiple approaches are available. Select 'yes', 'no', or 'random'.",
+    )
+
+    parser.addoption(
+        "-T",
+        "--tabular",
+        action="store",
+        default="raw",
+        dest="TABULAR",
+        help="Configure tabular data representation for model input. Select 'raw', 'recarray', or 'dataframe'.",
     )
 
 

--- a/modflow_devtools/test/test_fixtures.py
+++ b/modflow_devtools/test/test_fixtures.py
@@ -316,3 +316,34 @@ def test_pandas(pandas, arg, function_tmpdir):
         assert "True" in res
     elif pandas == "no":
         assert "False" in res
+
+
+test_tabular_fname = "tabular.txt"
+
+
+@pytest.mark.meta("test_tabular")
+def test_tabular_inner(function_tmpdir, tabular):
+    with open(function_tmpdir / test_tabular_fname, "w") as f:
+        f.write(str(tabular))
+
+
+@pytest.mark.parametrize("tabular", ["raw", "recarray", "dataframe"])
+@pytest.mark.parametrize("arg", ["--tabular", "-T"])
+def test_tabular(tabular, arg, function_tmpdir):
+    inner_fn = test_tabular_inner.__name__
+    args = [
+        __file__,
+        "-v",
+        "-s",
+        "-k",
+        inner_fn,
+        arg,
+        tabular,
+        "--keep",
+        function_tmpdir,
+        "-M",
+        "test_tabular",
+    ]
+    assert pytest.main(args) == ExitCode.OK
+    res = open(next(function_tmpdir.rglob(test_tabular_fname))).readlines()[0]
+    assert tabular == res


### PR DESCRIPTION
Followup on #112, introduce `tabular` fixture with `--tabular` CLI arg accepting `raw`, `recarray`, or `dataframe`. The previously introduced `use_pandas` fixture can condition whether the module under test uses pandas for internal work, the `tabular` fixture can select how input data is provided, leaving open the possibility for alternative representations in future