### PR TITLE
feat(executables): support .get(key, default) like dict

### DIFF
--- a/autotest/test_executables.py
+++ b/autotest/test_executables.py
@@ -1,4 +1,3 @@
-import subprocess
 import sys
 from pathlib import Path
 from shutil import which
@@ -24,3 +23,6 @@ def exes():
 def test_access(exes):
     # support both attribute and dictionary style access
     assert exes.pytest == exes["pytest"] == exe_path
+    # .get() works too
+    assert exes.get("not a target") is None
+    assert exes.get("not a target", exes["pytest"]) == exes["pytest"]

--- a/docs/md/executables.md
+++ b/docs/md/executables.md
@@ -28,4 +28,6 @@ The `targets` fixture can then be injected into test functions:
 def test_targets(targets):
     # attribute- and dictionary-style access is supported
     assert targets["mf6"] == targets.mf6
+    # .get() works too
+    assert targets.get("not a target") is None
 ```

--- a/modflow_devtools/executables.py
+++ b/modflow_devtools/executables.py
@@ -17,6 +17,9 @@ class Executables(SimpleNamespace):
     def __getitem__(self, key):
         return self.__dict__[key]
 
+    def get(self, key, default=None):
+        return self.as_dict().get(key, default)
+
     def as_dict(self) -> Dict[str, Path]:
         """
         Returns a dictionary mapping executable names to paths.


### PR DESCRIPTION
* add `.get(key, default=None)` method to `Executables` class