### PR TITLE
refactor(fixtures): support pytest>=8, drop pytest-cases dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ app
 # in case developer installs modflow executables in the project root
 bin
 
+**.DS_Store

--- a/autotest/test_fixtures.py
+++ b/autotest/test_fixtures.py
@@ -186,7 +186,7 @@ def test_keep_session_scoped_tmpdir(tmp_path, arg, request):
     ]
     assert pytest.main(args) == ExitCode.OK
     assert Path(
-        tmp_path / f"{request.session.name}0" / test_keep_fname
+        tmp_path / f"{request.config.rootpath.name}0" / test_keep_fname
     ).is_file()
 
 

--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -71,7 +71,7 @@ def module_tmpdir(tmpdir_factory, request) -> Path:
 
 @pytest.fixture(scope="session")
 def session_tmpdir(tmpdir_factory, request) -> Path:
-    temp = Path(tmpdir_factory.mktemp(request.session.name))
+    temp = Path(tmpdir_factory.mktemp(request.config.rootpath.name))
     yield temp
 
     keep = request.config.option.KEEP

--- a/modflow_devtools/ostags.py
+++ b/modflow_devtools/ostags.py
@@ -3,7 +3,6 @@ MODFLOW 6, Python3, and GitHub Actions refer to operating
 systems differently. This module contains conversion utilities.
 """
 
-
 import sys
 from enum import Enum
 from platform import system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ test = [
     "ninja",
     "numpy",
     "pytest",
-    "pytest-cases",
     "pytest-cov",
     "pytest-dotenv",
     "pytest-xdist",

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -106,7 +106,7 @@ if __name__ == "__main__":
     else:
         update_version(
             timestamp=datetime.now(),
-            version=Version(args.version)
-            if args.version
-            else _current_version,
+            version=(
+                Version(args.version) if args.version else _current_version
+            ),
         )


### PR DESCRIPTION
* pytest 8 sets `request.session.name` to the empty string where previously it was the pytest root workspace name, use `request.config.rootpath.name` instead
  * https://github.com/pytest-dev/pytest/releases/tag/8.0.0rc1
* drop `pytest-cases` optional dependency as it is unused and not yet supported by pytest 8
  * https://github.com/smarie/python-pytest-cases/issues/330