### PR TITLE
ci(release): remove reset step from release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,16 @@ on:
   push:
     paths-ignore:
       - '**.md'
+      - '.github/workflows/release.yml'
+      - '.gitignore'
   pull_request:
     branches:
       - main
       - develop
     paths-ignore:
       - '**.md'
+      - '.github/workflows/release.yml'
+      - '.gitignore'
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           body='
           # Release '$ver'
           
-          The release can be approved by merging this pull request into `main`. This will trigger jobs to publish the release to PyPI and reset `develop` from `main`, incrementing the patch version number.
+          The release can be approved by merging this pull request into `main`. This will trigger a job to publish the release to PyPI.
           
           ## Changelog
           
@@ -200,68 +200,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-
-  reset:
-    name: Draft reset PR
-    if: ${{ github.event_name == 'release' }}
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-
-      - name: Checkout main branch
-        uses: actions/checkout@v3
-        with:
-          ref: main
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.8
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
-
-      - name: Install Python dependencies
-        run: |
-          pip install --upgrade pip
-          pip install .
-          pip install ".[lint, test]"
-
-      - name: Get release tag
-        uses: oprypin/find-latest-tag@v1
-        id: latest_tag
-        with:
-          repository: ${{ github.repository }}
-          releases-only: true
-
-      - name: Draft pull request
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          # create reset branch from main
-          reset_branch="post-release-${{ steps.latest_tag.outputs.tag }}-reset"
-          git switch -c $reset_branch
-
-          # increment minor version
-          major_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f1)
-          minor_version=$(echo "${{ steps.latest_tag.outputs.tag }}" | cut -d. -f2)
-          version="$major_version.$((minor_version + 1)).0.dev0"
-          python scripts/update_version.py -v "$version"
-          python scripts/lint.py
-
-          # commit and push reset branch
-          git config core.sharedRepository true
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "ci(release): update to development version $version"
-          git push -u origin $reset_branch
-
-          # create PR into develop
-          body='
-          # Reinitialize for development
-
-          Updates the `develop` branch from `main` following a successful release. Increments the patch version number.
-          '
-          gh pr create -B "develop" -H "$reset_branch" --title "Reinitialize develop branch" --draft --body "$body"

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ app
 bin
 
 **.DS_Store
+data_backup


### PR DESCRIPTION
* not always known what next development version will be, just follow recent decision in flopy/modflowapi/pywatershed not to automate the reset PR