### PR TITLE
feat(ostags): apple silicon

### DIFF
--- a/autotest/test_ostags.py
+++ b/autotest/test_ostags.py
@@ -1,15 +1,16 @@
-from platform import system
+from platform import processor, system
 
 import pytest
 
 from modflow_devtools.ostags import (
-    OSTag,
+    convert_ostag,
     get_binary_suffixes,
     get_github_ostag,
     get_modflow_ostag,
 )
 
 _system = system()
+_processor = processor()
 
 
 def test_get_modflow_ostag():
@@ -19,7 +20,7 @@ def test_get_modflow_ostag():
     elif _system == "Linux":
         assert t == "linux"
     elif _system == "Darwin":
-        assert t == "mac"
+        assert t == "macarm" if _processor == "arm" else "mac"
     else:
         pytest.skip(reason="Unsupported platform")
 
@@ -35,17 +36,17 @@ def test_get_github_ostag():
 
 
 @pytest.mark.parametrize(
-    "cvt,tag,exp",
+    "map,tag,exp",
     [
         ("py2mf", "Windows", "win64"),
         ("mf2py", "win64", "Windows"),
-        ("py2mf", "Darwin", "mac"),
+        ("py2mf", "Darwin", "macarm" if _processor == "arm" else "mac"),
         ("mf2py", "mac", "Darwin"),
         ("py2mf", "Linux", "linux"),
         ("mf2py", "linux", "Linux"),
         ("gh2mf", "Windows", "win64"),
         ("mf2gh", "win64", "Windows"),
-        ("gh2mf", "macOS", "mac"),
+        ("gh2mf", "macOS", "macarm" if _processor == "arm" else "mac"),
         ("mf2gh", "mac", "macOS"),
         ("gh2mf", "Linux", "linux"),
         ("mf2gh", "linux", "Linux"),
@@ -57,8 +58,8 @@ def test_get_github_ostag():
         ("gh2py", "Linux", "Linux"),
     ],
 )
-def test_ostag_convert(cvt, tag, exp):
-    assert OSTag.convert(tag, cvt) == exp
+def test_convert_ostag(map, tag, exp):
+    assert convert_ostag(tag, map) == exp
 
 
 def test_get_binary_suffixes():

--- a/docs/md/ostags.md
+++ b/docs/md/ostags.md
@@ -14,7 +14,7 @@ Python3's `platform.system()` returns "Linux", "Darwin", and "Windows", respecti
 
 GitHub Actions (e.g. `runner.os` context) use "Linux", "macOS" and "Windows".
 
-MODFLOW 6 release asset names end with "linux", "mac" or "win64".
+MODFLOW 6 release asset names end with "linux", "mac" (Intel), "macarm", "win32", or "win64".
 
 ## Getting tags
 
@@ -37,7 +37,8 @@ Conversion functions are available for each direction:
 Alternatively:
 
 ```python
-OSTag.convert(platform.system(), "py2mf")
+convert_ostag(platform.system(), "py2mf") # prints linux, mac, macarm, win32, or win64
+convert_ostag(platform.system(), "py2mf") # prints Linux, macOS, or Windows
 ```
 
 The second argument specifies the mapping in format `<source>2<target>`, where `<source>` and `<target>` may take values `py`, `mf`, or `gh`.

--- a/modflow_devtools/ostags.py
+++ b/modflow_devtools/ostags.py
@@ -4,11 +4,13 @@ systems differently. This module contains conversion utilities.
 """
 
 import sys
-from enum import Enum
-from platform import system
+from platform import processor, system
 from typing import Tuple
 
 _system = system()
+_processor = processor()
+
+SUPPORTED_OSTAGS = ["linux", "mac", "macarm", "win32", "win64"]
 
 
 def get_modflow_ostag() -> str:
@@ -17,7 +19,7 @@ def get_modflow_ostag() -> str:
     elif _system == "Linux":
         return "linux"
     elif _system == "Darwin":
-        return "mac"
+        return "macarm" if _processor == "arm" else "mac"
     else:
         raise NotImplementedError(f"Unsupported system: {_system}")
 
@@ -29,6 +31,15 @@ def get_github_ostag() -> str:
         return "macOS"
     else:
         raise NotImplementedError(f"Unsupported system: {_system}")
+
+
+def get_ostag(kind: str = "modflow") -> str:
+    if kind == "modflow":
+        return get_modflow_ostag()
+    elif kind == "github":
+        return get_github_ostag()
+    else:
+        raise ValueError(f"Invalid kind: {kind}")
 
 
 def get_binary_suffixes(ostag: str = None) -> Tuple[str, str]:
@@ -55,10 +66,10 @@ def get_binary_suffixes(ostag: str = None) -> Tuple[str, str]:
             return ".exe", ".dll"
         elif tag == "linux":
             return "", ".so"
-        elif tag == "mac" or tag == "darwin":
+        elif tag == "darwin" or "mac" in tag:
             return "", ".dylib"
         else:
-            raise KeyError(f"unrecognized OS tag: {tag!r}")
+            raise KeyError(f"Invalid OS tag: {tag!r}")
 
     try:
         return _suffixes(ostag.lower())
@@ -89,9 +100,9 @@ def python_to_modflow_ostag(tag: str) -> str:
     elif tag == "Linux":
         return "linux"
     elif tag == "Darwin":
-        return "mac"
+        return "macarm" if _processor == "arm" else "mac"
     else:
-        raise ValueError(f"Invalid or unsupported tag: {tag}")
+        raise ValueError(f"Invalid tag: {tag}")
 
 
 def modflow_to_python_ostag(tag: str) -> str:
@@ -112,10 +123,10 @@ def modflow_to_python_ostag(tag: str) -> str:
         return "Windows"
     elif tag == "linux":
         return "Linux"
-    elif tag == "mac":
+    elif "mac" in tag:
         return "Darwin"
     else:
-        raise ValueError(f"Invalid or unsupported tag: {tag}")
+        raise ValueError(f"Invalid tag: {tag}")
 
 
 def modflow_to_github_ostag(tag: str) -> str:
@@ -123,7 +134,7 @@ def modflow_to_github_ostag(tag: str) -> str:
         return "Windows"
     elif tag == "linux":
         return "Linux"
-    elif tag == "mac":
+    elif "mac" in tag:
         return "macOS"
     else:
         raise ValueError(f"Invalid modflow os tag: {tag}")
@@ -135,7 +146,7 @@ def github_to_modflow_ostag(tag: str) -> str:
     elif tag == "Linux":
         return "linux"
     elif tag == "macOS":
-        return "mac"
+        return "macarm" if _processor == "arm" else "mac"
     else:
         raise ValueError(f"Invalid github os tag: {tag}")
 
@@ -148,39 +159,18 @@ def github_to_python_ostag(tag: str) -> str:
     return modflow_to_python_ostag(github_to_modflow_ostag(tag))
 
 
-def get_ostag(kind: str = "modflow") -> str:
-    if kind == "modflow":
-        return get_modflow_ostag()
-    elif kind == "github":
-        return get_github_ostag()
+def convert_ostag(tag: str, mapping: str) -> str:
+    if mapping == "py2mf":
+        return python_to_modflow_ostag(tag)
+    elif mapping == "mf2py":
+        return modflow_to_python_ostag(tag)
+    elif mapping == "gh2mf":
+        return github_to_modflow_ostag(tag)
+    elif mapping == "mf2gh":
+        return modflow_to_github_ostag(tag)
+    elif mapping == "py2gh":
+        return python_to_github_ostag(tag)
+    elif mapping == "gh2py":
+        return github_to_python_ostag(tag)
     else:
-        raise ValueError(f"Invalid kind: {kind}")
-
-
-class OSTagCvt(Enum):
-    py2mf = "py2mf"
-    mf2py = "mf2py"
-    gh2mf = "gh2mf"
-    mf2gh = "mf2gh"
-    py2gh = "py2gh"
-    gh2py = "gh2py"
-
-
-class OSTag:
-    @staticmethod
-    def convert(tag: str, cvt: str) -> str:
-        cvt = OSTagCvt(cvt)
-        if cvt == OSTagCvt.py2mf:
-            return python_to_modflow_ostag(tag)
-        elif cvt == OSTagCvt.mf2py:
-            return modflow_to_python_ostag(tag)
-        elif cvt == OSTagCvt.gh2mf:
-            return github_to_modflow_ostag(tag)
-        elif cvt == OSTagCvt.mf2gh:
-            return modflow_to_github_ostag(tag)
-        elif cvt == OSTagCvt.py2gh:
-            return python_to_github_ostag(tag)
-        elif cvt == OSTagCvt.gh2py:
-            return github_to_python_ostag(tag)
-        else:
-            raise ValueError(f"Unsupported mapping: {cvt}")
+        raise ValueError(f"Invalid mapping: {mapping}")


### PR DESCRIPTION
* add `macarm` tag for apple silicon macs
* remove `OSTags` class, refactor `OSTags.convert()` -> `convert_ostag()`
* update docs and tests