### PR TITLE
feat(markers): add no_parallel marker, support differing pkg/module names

### DIFF
--- a/autotest/test_markers.py
+++ b/autotest/test_markers.py
@@ -7,6 +7,7 @@ from packaging.version import Version
 
 from modflow_devtools.markers import (
     excludes_platform,
+    no_parallel,
     require_exe,
     require_package,
     require_platform,
@@ -75,3 +76,18 @@ def test_requires_python(version):
     if Version(py_ver) >= Version(version):
         assert requires_python(version)
         assert require_python(version)
+
+
+@no_parallel
+@requires_pkg("pytest-xdist", name_map={"pytest-xdist": "xdist"})
+def test_no_parallel(worker_id):
+    """
+    Should only run with xdist disabled, in which case:
+        - xdist environment variables are not set
+        - worker_id is 'master' (assuming xdist is installed)
+
+    See https://pytest-xdist.readthedocs.io/en/stable/how-to.html#identifying-the-worker-process-during-a-test.
+    """
+
+    assert environ.get("PYTEST_XDIST_WORKER") is None
+    assert worker_id == "master"

--- a/docs/md/markers.md
+++ b/docs/md/markers.md
@@ -80,6 +80,18 @@ Markers are also provided to ping network resources and skip if unavailable:
 - `@requires_github`: skips if `github.com` is unreachable
 - `@requires_spatial_reference`: skips if `spatialreference.org` is unreachable
 
+A marker is also available to skip tests if `pytest` is running in parallel with [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/latest/):
+
+```python
+from os import environ
+from modflow_devtools.markers import no_parallel
+
+@no_parallel
+def test_only_serially():
+    # https://pytest-xdist.readthedocs.io/en/stable/how-to.html#identifying-the-worker-process-during-a-test.
+    assert environ.get("PYTEST_XDIST_WORKER") is None
+```
+
 ## Aliases
 
 All markers are aliased to imperative mood, e.g. `require_github`. Some have other aliases as well:

--- a/modflow_devtools/markers.py
+++ b/modflow_devtools/markers.py
@@ -3,7 +3,9 @@ Pytest markers to toggle tests based on environment conditions.
 Occasionally useful to directly assert environment expectations.
 """
 
+from os import environ
 from platform import python_version, system
+from typing import Dict, Optional
 
 from packaging.version import Version
 
@@ -46,8 +48,8 @@ def requires_python(version, bound="lower"):
         )
 
 
-def requires_pkg(*pkgs):
-    missing = {pkg for pkg in pkgs if not has_pkg(pkg, strict=True)}
+def requires_pkg(*pkgs, name_map: Optional[Dict[str, str]] = None):
+    missing = {pkg for pkg in pkgs if not has_pkg(pkg, strict=True, name_map=name_map)}
     return pytest.mark.skipif(
         missing,
         reason=f"missing package{'s' if len(missing) != 1 else ''}: "
@@ -79,6 +81,11 @@ def excludes_branch(branch):
     return pytest.mark.skipif(
         current == branch, reason=f"can't run on branch: {branch}"
     )
+
+
+no_parallel = pytest.mark.skipif(
+    environ.get("PYTEST_XDIST_WORKER_COUNT"), reason="can't run in parallel"
+)
 
 
 requires_github = pytest.mark.skipif(


### PR DESCRIPTION
* add `no_parallel` marker to `modflow_devtools.markers` to skip test if xdist is activated
* add `name_map` param to `has_pkg()` function and `requires_pkg` marker &mdash; accommodate packages which don't have a correspondingly named top-level module, e.g. `pytext-xdist` -> `xdist`, `mfpymake` -> `pymake`
* minor refactor in `has_pkg()` and update docstrings