### PR TITLE
fix(get_model_paths): fix model order within scenario

### DIFF
--- a/autotest/test_misc.py
+++ b/autotest/test_misc.py
@@ -151,12 +151,12 @@ def get_expected_namefiles(path, pattern="mfsim.nam") -> List[Path]:
 def test_get_model_paths_examples():
     expected_paths = get_expected_model_dirs(_examples_path)
     paths = get_model_paths(_examples_path)
-    assert paths == sorted(list(set(paths)))  # no duplicates
+    assert sorted(paths) == sorted(list(set(paths)))  # no duplicates
     assert set(expected_paths) == set(paths)
 
     expected_paths = get_expected_model_dirs(_examples_path, "*.nam")
     paths = get_model_paths(_examples_path, namefile="*.nam")
-    assert paths == sorted(list(set(paths)))
+    assert sorted(paths) == sorted(list(set(paths)))
     assert set(expected_paths) == set(paths)
 
 
@@ -166,12 +166,12 @@ def test_get_model_paths_examples():
 def test_get_model_paths_largetestmodels():
     expected_paths = get_expected_model_dirs(_examples_path)
     paths = get_model_paths(_examples_path)
-    assert paths == sorted(list(set(paths)))
+    assert sorted(paths) == sorted(list(set(paths)))
     assert set(expected_paths) == set(paths)
 
     expected_paths = get_expected_model_dirs(_examples_path)
     paths = get_model_paths(_examples_path)
-    assert paths == sorted(list(set(paths)))
+    assert sorted(paths) == sorted(list(set(paths)))
     assert set(expected_paths) == set(paths)
 
 


### PR DESCRIPTION
Sort models within each scenario so models can be run in the order returned by `get_model_paths()`, with flow models preceding other model types. This is critical since this function is used to generate scripts for running the examples which are included in the distribution.