### PR TITLE
feat(snapshots): add --snapshot-disable cli option

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -1,4 +1,4 @@
 from pathlib import Path
 
-pytest_plugins = ["modflow_devtools.fixtures"]
+pytest_plugins = ["modflow_devtools.fixtures", "modflow_devtools.snapshots"]
 project_root_path = Path(__file__).parent

--- a/autotest/test_snapshots.py
+++ b/autotest/test_snapshots.py
@@ -2,10 +2,11 @@ import inspect
 from pathlib import Path
 
 import numpy as np
+import pytest
+from _pytest.config import ExitCode
 
 proj_root = Path(__file__).parents[1]
 module_path = Path(inspect.getmodulename(__file__))
-pytest_plugins = ["modflow_devtools.snapshots"]  # activate snapshot fixtures
 snapshot_array = np.array([1.1, 2.2, 3.3])
 snapshots_path = proj_root / "autotest" / "__snapshots__"
 
@@ -61,3 +62,47 @@ def test_readable_text_array_snapshot(readable_array_snapshot):
         ),
         snapshot_array,
     )
+
+
+@pytest.mark.meta("test_snapshot_disable")
+def test_snapshot_disable_inner(snapshot):
+    assert snapshot == "match this!"
+
+
+@pytest.mark.parametrize("disable", [True, False])
+def test_snapshot_disable(disable):
+    inner_fn = test_snapshot_disable_inner.__name__
+    args = [
+        __file__,
+        "-v",
+        "-s",
+        "-k",
+        inner_fn,
+        "-M",
+        "test_snapshot_disable",
+    ]
+    if disable:
+        args.append("--snapshot-disable")
+    assert pytest.main(args) == (ExitCode.OK if disable else ExitCode.TESTS_FAILED)
+
+
+@pytest.mark.meta("test_array_snapshot_disable")
+def test_array_snapshot_disable_inner(array_snapshot):
+    assert array_snapshot == "can you match that?"
+
+
+@pytest.mark.parametrize("disable", [True, False])
+def test_array_snapshot_disable(disable):
+    inner_fn = test_array_snapshot_disable_inner.__name__
+    args = [
+        __file__,
+        "-v",
+        "-s",
+        "-k",
+        inner_fn,
+        "-M",
+        "test_array_snapshot_disable",
+    ]
+    if disable:
+        args.append("--snapshot-disable")
+    assert pytest.main(args) == (ExitCode.OK if disable else ExitCode.TESTS_FAILED)

--- a/docs/md/snapshots.md
+++ b/docs/md/snapshots.md
@@ -15,3 +15,7 @@ To use snapshot fixtures, add the following line to a test file or `conftest.py`
 ```python
 pytest_plugins = [ "modflow_devtools.snapshots" ]
 ```
+
+## Disable snapshots
+
+Snapshot comparisons can be disabled by invoked `pytest` with the `--snapshot-disable` flag.


### PR DESCRIPTION
* add `--snapshot-disable` pytest CLI option to disable snapshot comparisons
* if snapshots are disabled, the snapshot fixture provided to the test function will attest equivalence to anything, e.g. `snapshot == "yes, anything"` returns `True`