### PR TITLE
chore: fix typos and add codespell check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,15 @@ jobs:
       - name: Install Python packages
         run: pip install ".[lint]"
 
-      - name: Run ruff
-        run: ruff check .
-  
+      - name: Run ruff check
+        run: ruff check
+
+      - name: Run ruff format
+        run: ruff format --check
+
+      - name: Check spelling
+        run: codespell
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/autotest/test_misc.py
+++ b/autotest/test_misc.py
@@ -103,7 +103,7 @@ def test_get_packages_fails_on_invalid_namefile(module_tmpdir):
             f.write(line + os.linesep)
     assert set(get_packages(namefile_path)) == {"gwf", "tdis", "ims"}
 
-    # entirely unparseable namefile - result should be empty
+    # entirely unparsable namefile - result should be empty
     lines = open(namefile_path, "r").read().splitlines()
     with open(namefile_path, "w") as f:
         for _ in lines:

--- a/modflow_devtools/misc.py
+++ b/modflow_devtools/misc.py
@@ -120,7 +120,7 @@ def run_py_script(script, *args, verbose=False):
 def get_current_branch() -> str:
     """
     Tries to determine the name of the current branch, first by the GITHUB_REF
-    environent variable, then by asking ``git`` if GITHUB_REF is not set.
+    environment variable, then by asking ``git`` if GITHUB_REF is not set.
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 lint = [
+    "codespell[toml]",
     "ruff"
 ]
 test = [
@@ -73,20 +74,6 @@ docs = [
 "Bug Tracker" = "https://github.com/MODFLOW-USGS/modflow-devtools/issues"
 "Source Code" = "https://github.com/MODFLOW-USGS/modflow-devtools"
 
-[tool.ruff]
-target-version = "py38"
-include = [
-    "pyproject.toml",
-    "modflow_devtools/**/*.py",
-    "autotest/**/*.py",
-    "docs/**/*.py",
-    "scripts/**/*.py",
-    ".github/**/*.py",
-]
-
-[tool.ruff.lint]
-select = ["F", "E", "I001"]
-
 [tool.setuptools]
 packages = ["modflow_devtools"]
 include-package-data = true
@@ -97,6 +84,19 @@ version = {file = "version.txt"}
 
 [tool.setuptools_scm]
 fallback_version = "999"
+
+[tool.codespell]
+skip = "cliff.toml"
+ignore-words-list = [
+    "nam",
+    "wel",
+]
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["F", "E", "I001"]
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]


### PR DESCRIPTION
This fixes a few typos and adds a configuration for codespell, which is also run in CI.

The ruff configuration is simplified (and re-ordered) to remove `target-version` and `include`, but the rules are not revised.