### PR TITLE
ci: use macos-13 image instead of macos-12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
+        os: [ ubuntu-22.04, macos-13, windows-2022 ]
         python: [ 3.8, 3.9, "3.10", "3.11", "3.12" ]
     env:
       GCC_V: 11


### PR DESCRIPTION
The `macos-12` image is deprecated and not supported. Upgrade to `macos-13`, which is still supported.