### PR TITLE
refactor: use pathlib and subprocess; refactor other aspects

### DIFF
--- a/autotest/test_download.py
+++ b/autotest/test_download.py
@@ -53,9 +53,9 @@ def test_get_release(repo):
     if repo == "MODFLOW-USGS/modflow6":
         # can remove if modflow6 releases follow asset name
         # conventions followed in executables and nightly build repos
-        assert set([a.rpartition("_")[2] for a in actual_names]) >= set(
-            [a for a in expected_names if not a.startswith("win")]
-        )
+        assert {a.rpartition("_")[2] for a in actual_names} >= {
+            a for a in expected_names if not a.startswith("win")
+        }
     else:
         assert set(actual_names) >= set(expected_names)
 
@@ -64,7 +64,7 @@ def test_get_release(repo):
 @requires_github
 @pytest.mark.parametrize("name", [None, "rtd-files", "run-time-comparison"])
 @pytest.mark.parametrize("per_page", [None, 100])
-def test_list_artifacts(tmp_path, name, per_page):
+def test_list_artifacts(name, per_page):
     artifacts = list_artifacts(
         "MODFLOW-USGS/modflow6",
         name=name,

--- a/autotest/test_misc.py
+++ b/autotest/test_misc.py
@@ -22,10 +22,10 @@ from modflow_devtools.misc import (
 
 
 def test_set_dir(tmp_path):
-    assert Path(os.getcwd()) != tmp_path
+    assert Path.cwd() != tmp_path
     with set_dir(tmp_path):
-        assert Path(os.getcwd()) == tmp_path
-    assert Path(os.getcwd()) != tmp_path
+        assert Path.cwd() == tmp_path
+    assert Path.cwd() != tmp_path
 
 
 def test_set_env():
@@ -49,17 +49,13 @@ if _repos_path is None:
     _repos_path = Path(__file__).parent.parent.parent.parent
 _repos_path = Path(_repos_path).expanduser().absolute()
 _testmodels_repo_path = _repos_path / "modflow6-testmodels"
-_testmodels_repo_paths_mf6 = sorted(list((_testmodels_repo_path / "mf6").glob("test*")))
-_testmodels_repo_paths_mf5to6 = sorted(
-    list((_testmodels_repo_path / "mf5to6").glob("test*"))
-)
+_testmodels_repo_paths_mf6 = sorted((_testmodels_repo_path / "mf6").glob("test*"))
+_testmodels_repo_paths_mf5to6 = sorted((_testmodels_repo_path / "mf5to6").glob("test*"))
 _largetestmodels_repo_path = _repos_path / "modflow6-largetestmodels"
-_largetestmodel_paths = sorted(list(_largetestmodels_repo_path.glob("test*")))
+_largetestmodel_paths = sorted(_largetestmodels_repo_path.glob("test*"))
 _examples_repo_path = _repos_path / "modflow6-examples"
 _examples_path = _examples_repo_path / "examples"
-_example_paths = (
-    sorted(list(_examples_path.glob("ex-*"))) if _examples_path.is_dir() else []
-)
+_example_paths = sorted(_examples_path.glob("ex-*")) if _examples_path.is_dir() else []
 
 
 @pytest.mark.skipif(
@@ -95,20 +91,19 @@ def test_get_packages_fails_on_invalid_namefile(module_tmpdir):
 
     # invalid gwf namefile reference:
     # result should only contain packages from mfsim.nam
-    lines = open(namefile_path, "r").read().splitlines()
-    with open(namefile_path, "w") as f:
-        for line in lines:
-            if "GWF6" in line:
-                line = line.replace("GWF6", "GWF6  garbage")
-            f.write(line + os.linesep)
-    assert set(get_packages(namefile_path)) == {"gwf", "tdis", "ims"}
+    lines = []
+    for line in namefile_path.read_text().splitlines():
+        if "GWF6" in line:
+            line = line.replace("GWF6", "GWF6  garbage")
+        lines.append(line)
+    namefile_path.write_text("\n".join(lines))
+
+    with pytest.warns(UserWarning, match="Invalid namefile format"):
+        assert set(get_packages(namefile_path)) == {"gwf", "tdis", "ims"}
 
     # entirely unparsable namefile - result should be empty
-    lines = open(namefile_path, "r").read().splitlines()
-    with open(namefile_path, "w") as f:
-        for _ in lines:
-            f.write("garbage" + os.linesep)
-    assert not any(get_packages(namefile_path))
+    namefile_path.write_text("garbage\n" * 20)
+    assert get_packages(namefile_path) == []
 
 
 @pytest.mark.skipif(not any(_example_paths), reason="examples not found")
@@ -129,34 +124,34 @@ def test_has_package():
 
 def get_expected_model_dirs(path, pattern="mfsim.nam") -> List[Path]:
     folders = []
-    for root, dirs, files in os.walk(path):
+    for root, dirs, _ in os.walk(path):
         for d in dirs:
             p = Path(root) / d
             if any(p.glob(pattern)):
                 folders.append(p)
-    return sorted(list(set(folders)))
+    return sorted(set(folders))
 
 
 def get_expected_namefiles(path, pattern="mfsim.nam") -> List[Path]:
     folders = []
-    for root, dirs, files in os.walk(path):
+    for root, dirs, _ in os.walk(path):
         for d in dirs:
             p = Path(root) / d
             found = list(p.glob(pattern))
             folders = folders + found
-    return sorted(list(set(folders)))
+    return sorted(set(folders))
 
 
 @pytest.mark.skipif(not any(_example_paths), reason="modflow6-examples repo not found")
 def test_get_model_paths_examples():
     expected_paths = get_expected_model_dirs(_examples_path)
     paths = get_model_paths(_examples_path)
-    assert sorted(paths) == sorted(list(set(paths)))  # no duplicates
+    assert sorted(paths) == sorted(set(paths))  # no duplicates
     assert set(expected_paths) == set(paths)
 
     expected_paths = get_expected_model_dirs(_examples_path, "*.nam")
     paths = get_model_paths(_examples_path, namefile="*.nam")
-    assert sorted(paths) == sorted(list(set(paths)))
+    assert sorted(paths) == sorted(set(paths))
     assert set(expected_paths) == set(paths)
 
 
@@ -166,12 +161,12 @@ def test_get_model_paths_examples():
 def test_get_model_paths_largetestmodels():
     expected_paths = get_expected_model_dirs(_examples_path)
     paths = get_model_paths(_examples_path)
-    assert sorted(paths) == sorted(list(set(paths)))
+    assert sorted(paths) == sorted(set(paths))
     assert set(expected_paths) == set(paths)
 
     expected_paths = get_expected_model_dirs(_examples_path)
     paths = get_model_paths(_examples_path)
-    assert sorted(paths) == sorted(list(set(paths)))
+    assert sorted(paths) == sorted(set(paths))
     assert set(expected_paths) == set(paths)
 
 
@@ -192,12 +187,12 @@ def test_get_model_paths_exclude_patterns(models):
 def test_get_namefile_paths_examples():
     expected_paths = get_expected_namefiles(_examples_path)
     paths = get_namefile_paths(_examples_path)
-    assert paths == sorted(list(set(paths)))
+    assert paths == sorted(set(paths))
     assert set(expected_paths) == set(paths)
 
     expected_paths = get_expected_namefiles(_examples_path, "*.nam")
     paths = get_namefile_paths(_examples_path, namefile="*.nam")
-    assert paths == sorted(list(set(paths)))
+    assert paths == sorted(set(paths))
     assert set(expected_paths) == set(paths)
 
 
@@ -207,12 +202,12 @@ def test_get_namefile_paths_examples():
 def test_get_namefile_paths_largetestmodels():
     expected_paths = get_expected_namefiles(_largetestmodels_repo_path)
     paths = get_namefile_paths(_largetestmodels_repo_path)
-    assert paths == sorted(list(set(paths)))
+    assert paths == sorted(set(paths))
     assert set(expected_paths) == set(paths)
 
     expected_paths = get_expected_namefiles(_largetestmodels_repo_path)
     paths = get_namefile_paths(_largetestmodels_repo_path)
-    assert paths == sorted(list(set(paths)))
+    assert paths == sorted(set(paths))
     assert set(expected_paths) == set(paths)
 
 

--- a/autotest/test_snapshots.py
+++ b/autotest/test_snapshots.py
@@ -56,10 +56,7 @@ def test_readable_text_array_snapshot(readable_array_snapshot):
     )
     assert snapshot_path.is_file()
     assert np.allclose(
-        np.fromstring(
-            open(snapshot_path).readlines()[0].replace("[", "").replace("]", ""),
-            sep=" ",
-        ),
+        np.fromstring(snapshot_path.read_text().strip("[]\r\n"), sep=" "),
         snapshot_array,
     )
 

--- a/autotest/test_zip.py
+++ b/autotest/test_zip.py
@@ -23,8 +23,8 @@ def test_compressall(function_tmpdir):
     zip_file = function_tmpdir / "output.zip"
     input_dir = function_tmpdir / "input"
     input_dir.mkdir()
-    with open(input_dir / "data.txt", "w") as f:
-        f.write("hello world")
+    file = input_dir / "data.txt"
+    file.write_text("hello world")
 
     MFZipFile.compressall(str(zip_file), dir_pths=str(input_dir))
     pprint(list(function_tmpdir.iterdir()))
@@ -42,8 +42,7 @@ def empty_archive(module_tmpdir) -> Path:
     # https://stackoverflow.com/a/25195628/6514033
     data = b"PK\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"  # noqa: E501
     path = module_tmpdir / "empty.zip"
-    with open(path, "wb") as zip:
-        zip.write(data)
+    path.write_bytes(data)
     yield path
 
 

--- a/modflow_devtools/download.py
+++ b/modflow_devtools/download.py
@@ -396,13 +396,13 @@ def download_artifact(
         if github_token:
             request.add_header("Authorization", f"Bearer {github_token}")
 
-    zip_path = Path(path).expanduser().absolute() / f"{str(uuid4())}.zip"
+    zip_path = Path(path).expanduser().absolute() / f"{uuid4()!s}.zip"
     tries = 0
     while True:
         tries += 1
         try:
-            with urllib.request.urlopen(request) as url_file, open(
-                zip_path, "wb"
+            with urllib.request.urlopen(request) as url_file, zip_path.open(
+                "wb"
             ) as out_file:
                 content = url_file.read()
                 out_file.write(content)
@@ -456,8 +456,10 @@ def download_and_unzip(
     Path
         The path to the directory where the zip file was unzipped
     """
-
-    path = Path(path if path else os.getcwd())
+    if path:
+        path = Path(path)
+    else:
+        path = Path.cwd()
     path.mkdir(exist_ok=True)
 
     if verbose:
@@ -477,8 +479,8 @@ def download_and_unzip(
     while True:
         tries += 1
         try:
-            with urllib.request.urlopen(request) as url_file, open(
-                file_path, "wb"
+            with urllib.request.urlopen(request) as url_file, file_path.open(
+                "wb"
             ) as out_file:
                 content = url_file.read()
                 out_file.write(content)

--- a/modflow_devtools/fixtures.py
+++ b/modflow_devtools/fixtures.py
@@ -319,7 +319,7 @@ def pytest_generate_tests(metafunc):
                 namefile_paths, key=example_name_from_namfile_path
             ):
                 # sort alphabetically (gwf < gwt)
-                nfpaths = sorted(list(paths))
+                nfpaths = sorted(paths)
 
                 # skip if no models found
                 if len(nfpaths) == 0:
@@ -333,9 +333,7 @@ def pytest_generate_tests(metafunc):
             # find MODFLOW 6 namfiles
             examples_path = repo_path / "examples"
             namfiles = (
-                [p for p in examples_path.rglob("mfsim.nam")]
-                if examples_path.is_dir()
-                else []
+                list(examples_path.rglob("mfsim.nam")) if examples_path.is_dir() else []
             )
 
             # group by scenario
@@ -377,9 +375,9 @@ def pytest_generate_tests(metafunc):
 
             return examples
 
-        example_scenarios = get_examples() if repo_path else dict()
+        example_scenarios = get_examples() if repo_path else {}
         metafunc.parametrize(
             key,
-            [(name, nfps) for name, nfps in example_scenarios.items()],
+            list(example_scenarios.items()),
             ids=list(example_scenarios.keys()),
         )

--- a/modflow_devtools/latex.py
+++ b/modflow_devtools/latex.py
@@ -1,14 +1,14 @@
 from os import PathLike
 from pathlib import Path
-from typing import Iterable, Union
+from typing import Iterable, Optional, Union
 
 
 def build_table(
     caption: str,
     fpth: Union[str, PathLike],
     arr,
-    headings: Iterable[str] = None,
-    col_widths: Iterable[float] = None,
+    headings: Optional[Iterable[str]] = None,
+    col_widths: Optional[Iterable[float]] = None,
 ):
     """
     Build a LaTeX table from the given NumPy array.
@@ -32,7 +32,7 @@ def build_table(
     if headings is None:
         headings = arr.dtype.names
     ncols = len(arr.dtype.names)
-    label = "tab:{}".format(fpth.stem)
+    label = f"tab:{fpth.stem}"
 
     line = get_header(caption, label, headings, col_widths=col_widths)
 
@@ -49,15 +49,14 @@ def build_table(
     # footer
     line += get_footer()
 
-    with open(fpth, "w") as f:
-        f.write(line)
+    fpth.write_text(line)
 
 
 def get_header(
     caption: str,
     label: str,
     headings: Iterable[str],
-    col_widths: Iterable[float] = None,
+    col_widths: Optional[Iterable[float]] = None,
     center: bool = True,
     firsthead: bool = False,
 ):

--- a/modflow_devtools/ostags.py
+++ b/modflow_devtools/ostags.py
@@ -5,7 +5,7 @@ systems differently. This module contains conversion utilities.
 
 import sys
 from platform import processor, system
-from typing import Tuple
+from typing import Optional, Tuple
 
 _system = system()
 _processor = processor()
@@ -42,7 +42,7 @@ def get_ostag(kind: str = "modflow") -> str:
         raise ValueError(f"Invalid kind: {kind}")
 
 
-def get_binary_suffixes(ostag: str = None) -> Tuple[str, str]:
+def get_binary_suffixes(ostag: Optional[str] = None) -> Tuple[str, str]:
     """
     Returns executable and library suffixes for the given OS tag, if provided,
     otherwise for the current operating system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,20 @@ ignore-words-list = [
 line-length = 88
 
 [tool.ruff.lint]
-select = ["F", "E", "I001"]
+select = [
+    # "ARG",  # flake8-unused-arguments
+    "C4",   # flake8 comprehensions
+    "D409", # pydocstyle - section-underline-matches-section-length
+    "E", "W", # pycodestyle
+    "F",    # Pyflakes
+    "I",    # isort 
+    "PTH",  # flake8-use-pathlib
+    "RUF",  # Ruff-specific rules
+    "UP",   # pyupgrade
+]
+
+[tool.ruff.lint.per-file-ignores]
+"modflow_devtools/zip.py" = ["PTH"]
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -15,30 +15,29 @@ _current_version = Version(_version_txt_path.read_text().strip())
 
 
 def update_version_txt(version: Version):
-    with open(_version_txt_path, "w") as f:
-        f.write(str(version))
+    _version_txt_path.write_text(str(version))
     print(f"Updated {_version_txt_path} to version {version}")
 
 
 def update_init_py(timestamp: datetime, version: Version):
-    lines = _package_init_path.read_text().rstrip().split("\n")
-    with open(_package_init_path, "w") as f:
-        for line in lines:
-            if "__date__" in line:
-                line = f'__date__ = "{timestamp.strftime("%b %d, %Y")}"'
-            if "__version__" in line:
-                line = f'__version__ = "{version}"'
-            f.write(f"{line}\n")
+    lines = []
+    for line in _package_init_path.read_text().splitlines():
+        if "__date__" in line:
+            line = f'__date__ = "{timestamp:%b %d, %Y}"'
+        if "__version__" in line:
+            line = f'__version__ = "{version}"'
+        lines.append(line)
+    _package_init_path.write_text("\n".join(lines) + "\n")
     print(f"Updated {_package_init_path} to version {version}")
 
 
 def update_docs_config(version: Version):
-    lines = _docs_config_path.read_text().rstrip().split("\n")
-    with open(_docs_config_path, "w") as f:
-        for line in lines:
-            line = f"release = '{version}'" if "release = " in line else line
-            f.write(f"{line}\n")
-
+    lines = []
+    for line in _docs_config_path.read_text().splitlines():
+        if "release = " in line:
+            line = f'release = "{version}"'
+        lines.append(line)
+    _docs_config_path.write_text("\n".join(lines) + "\n")
     print(f"Updated {_docs_config_path} to version {version}")
 
 
@@ -59,6 +58,8 @@ def update_version(
         update_version_txt(version)
         update_init_py(timestamp, version)
         update_docs_config(version)
+
+    lock_path.unlink()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are several refactors combined in this PR:

- Use [pathlib](https://docs.python.org/3/library/pathlib.html) more consistently (also enforced with Ruff's [PTH](https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth) rule (except for modflow_devtools/zip.py)
- Refactor some aspects of `subprocess.run()` in `meson_build()` to not use `shell=True`. Also, run `meson compile ...` before `meson install ...`
- Apply some automated fixes from Ruff rules [C4](https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4), [RUF](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf) and [UP](https://docs.astral.sh/ruff/rules/#pyupgrade-up).
- Fix missing parameter in `test_fixtures.py::test_keep_function_scoped_tmpdir` (found via Ruff's [ARG](https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg) rule)