### PR TITLE
fix(dfn): mark transient blocks

### DIFF
--- a/modflow_devtools/dfn.py
+++ b/modflow_devtools/dfn.py
@@ -432,6 +432,12 @@ class Dfn(TypedDict):
             for block_name, block in groupby(vars_.values(), lambda v: v["block"])
         }
 
+        # mark transient blocks
+        transient_index_vars = flat.getlist("iper")
+        for transient_index in transient_index_vars:
+            transient_block = transient_index["block"]
+            blocks[transient_block]["transient"] = True
+
         # remove unneeded attributes
         def remove_attrs(path, key, value):
             if key in ["block", "in_record", "tagged", "preserve_case"]:


### PR DESCRIPTION
The `iper` variable was previously missed. It has `in_record true` but it's not in a record, as per mf6's definition, it's in the `period` block. I suppose `in_record` really means "is a child of a composite", which is in tension with the hard distinction mf6 makes between blocks and variables. In the TOML format we no longer need `in_record`.

IMO it's cleaner to just mark transient blocks as such instead of defining an extra `iper` index variable. This does mean that we will need to translate the transient flag back into "iper" terminology for the mf6io guide, e.g. for examples like

```
BEGIN PERIOD <iper>
  [SAVE <rtype> <ocsetting>]
  [PRINT <rtype> <ocsetting>]
END PERIOD
```