### PR TITLE
fix(dfn): keep block attribute for now

### DIFF
--- a/modflow_devtools/dfn.py
+++ b/modflow_devtools/dfn.py
@@ -435,7 +435,7 @@ class Dfn(TypedDict):
 
         # remove unneeded variable attributes
         def remove_attrs(path, key, value):
-            if key in ["block", "in_record", "tagged", "preserve_case"]:
+            if key in ["in_record", "tagged", "preserve_case"]:
                 return False
             return True
 


### PR DESCRIPTION
Flopy expects this for `mfstructure.py` introspection. Keep it for now and drop it once flopy no longer needs it.