### PR TITLE
refactor(dfn): rename _SCALAR_TYPES to public SCALAR_TYPES

### DIFF
--- a/modflow_devtools/dfn.py
+++ b/modflow_devtools/dfn.py
@@ -131,7 +131,7 @@ def get_blocks(dfn: "Dfn") -> Blocks:
     """
 
     def _is_block(item: tuple[str, Any]) -> bool:
-        k, v = item
+        k, _v = item
         return k not in Dfn.__annotations__
 
     return dict(


### PR DESCRIPTION
This variable is accessed externally ([here](https://github.com/modflowpy/flopy/blob/a49a7a7484586d10f1e2dbde5cad744554740de7/flopy/mf6/utils/codegen/filters.py#L237)), which means it should be a public variable, not private.

Keep a private `_SCALAR_TYPES` copy for now.