### PR TITLE
chore(dependencies): bound syrupy < 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
     "pytest-dotenv",
     "pytest-xdist",
     "PyYaml",
-    "syrupy"
+    "syrupy <5.0.0"
 ]
 docs = [
     "sphinx",
@@ -107,7 +107,7 @@ test = [
     "pytest-dotenv",
     "pytest-xdist",
     "PyYaml",
-    "syrupy"
+    "syrupy <5.0.0"
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
[version 5](https://github.com/syrupy-project/syrupy/releases/tag/v5.0.0) changes the snapshot naming convention and maybe other things