### PR TITLE
refactor(dfn): rename default -> default_value in schema map

### DIFF
--- a/modflow_devtools/dfn/__init__.py
+++ b/modflow_devtools/dfn/__init__.py
@@ -162,7 +162,7 @@ class MapV1To2(SchemaMap):
             shape = field_dict.pop("shape", None)
             shape = None if shape == "" else shape
             block = field_dict.pop("block", None)
-            default = field_dict.pop("default", None)
+            default = field_dict.pop("default_value", None)
             default = try_literal_eval(default) if _type != "string" else default
             description = field_dict.pop("description", "")
 

--- a/modflow_devtools/dfn/parse.py
+++ b/modflow_devtools/dfn/parse.py
@@ -28,7 +28,7 @@ def field_attr_sort_key(item) -> int:
         return 1
     if k == "shape":
         return 2
-    if k == "default":
+    if k == "default_value":
         return 3
     if k == "reader":
         return 4
@@ -145,8 +145,6 @@ def parse_dfn(f, common: dict | None = None) -> tuple[OMD, list[str]]:
 
         # parse field attribute
         key, _, value = line.partition(" ")
-        if key == "default_value":
-            key = "default"
         field[key] = value
 
         # if this is the description attribute, substitute


### PR DESCRIPTION
Any changes like this should happen in the v1 -> v2 schema map instead of in the DFN parser