### PR TITLE
feat(dfn): add from_dict method

### DIFF
--- a/autotest/test_dfn.py
+++ b/autotest/test_dfn.py
@@ -132,6 +132,34 @@ def test_dfn_from_dict_ignores_extra_keys():
     assert dfn.schema_version == Version("2")
 
 
+def test_dfn_from_dict_strict_mode():
+    d = {
+        "schema_version": Version("2"),
+        "name": "test-dfn",
+        "extra_key": "should cause error",
+    }
+    with pytest.raises(ValueError, match="Unrecognized keys in DFN data"):
+        Dfn.from_dict(d, strict=True)
+
+
+def test_dfn_from_dict_strict_mode_nested():
+    d = {
+        "schema_version": Version("2"),
+        "name": "test-dfn",
+        "blocks": {
+            "options": {
+                "test_field": {
+                    "name": "test_field",
+                    "type": "keyword",
+                    "extra_key": "should cause error",
+                },
+            },
+        },
+    }
+    with pytest.raises(ValueError, match="Unrecognized keys in field data"):
+        Dfn.from_dict(d, strict=True)
+
+
 def test_dfn_from_dict_roundtrip():
     original = Dfn(
         schema_version=Version("2"),
@@ -163,6 +191,16 @@ def test_fieldv1_from_dict_ignores_extra_keys():
     assert field.type == "keyword"
 
 
+def test_fieldv1_from_dict_strict_mode():
+    d = {
+        "name": "test_field",
+        "type": "keyword",
+        "extra_key": "should cause error",
+    }
+    with pytest.raises(ValueError, match="Unrecognized keys in field data"):
+        FieldV1.from_dict(d, strict=True)
+
+
 def test_fieldv1_from_dict_roundtrip():
     original = FieldV1(
         name="maxbound",
@@ -190,6 +228,16 @@ def test_fieldv2_from_dict_ignores_extra_keys():
     field = FieldV2.from_dict(d)
     assert field.name == "test_field"
     assert field.type == "keyword"
+
+
+def test_fieldv2_from_dict_strict_mode():
+    d = {
+        "name": "test_field",
+        "type": "keyword",
+        "extra_key": "should cause error",
+    }
+    with pytest.raises(ValueError, match="Unrecognized keys in field data"):
+        FieldV2.from_dict(d, strict=True)
 
 
 def test_fieldv2_from_dict_roundtrip():

--- a/modflow_devtools/dfn/schema/v1.py
+++ b/modflow_devtools/dfn/schema/v1.py
@@ -17,7 +17,21 @@ class FieldV1(Field):
     mf6internal: str | None = None
 
     @classmethod
-    def from_dict(cls, d: dict) -> "FieldV1":
-        """Create a FieldV1 instance from a dictionary."""
+    def from_dict(cls, d: dict, strict: bool = False) -> "FieldV1":
+        """
+        Create a FieldV1 instance from a dictionary.
+
+        Parameters
+        ----------
+        d : dict
+            Dictionary containing field data
+        strict : bool, optional
+            If True, raise ValueError if dict contains unrecognized keys.
+            If False (default), ignore unrecognized keys.
+        """
         keys = list(cls.__annotations__.keys()) + list(Field.__annotations__.keys())
+        if strict:
+            extra_keys = set(d.keys()) - set(keys)
+            if extra_keys:
+                raise ValueError(f"Unrecognized keys in field data: {extra_keys}")
         return cls(**{k: v for k, v in d.items() if k in keys})

--- a/modflow_devtools/dfn/schema/v2.py
+++ b/modflow_devtools/dfn/schema/v2.py
@@ -13,7 +13,21 @@ class FieldV2(Field):
     pass
 
     @classmethod
-    def from_dict(cls, d: dict) -> "FieldV2":
-        """Create a FieldV2 instance from a dictionary."""
+    def from_dict(cls, d: dict, strict: bool = False) -> "FieldV2":
+        """
+        Create a FieldV2 instance from a dictionary.
+
+        Parameters
+        ----------
+        d : dict
+            Dictionary containing field data
+        strict : bool, optional
+            If True, raise ValueError if dict contains unrecognized keys.
+            If False (default), ignore unrecognized keys.
+        """
         keys = list(cls.__annotations__.keys()) + list(Field.__annotations__.keys())
+        if strict:
+            extra_keys = set(d.keys()) - set(keys)
+            if extra_keys:
+                raise ValueError(f"Unrecognized keys in field data: {extra_keys}")
         return cls(**{k: v for k, v in d.items() if k in keys})


### PR DESCRIPTION
Allows using `Dfn`/`Field` spec objects explicitly by passing a dictionary to `__init__` via double star syntax, or via `from_dict` which handles field structuring automatically, and with `strict=False` ignores unrecognized keys (like pydantic's `extra="ignore"`), if `strict=True` unrecognized keys cause an error (like pydantic's `extra="forbid"`)