### PR TITLE
chore(dfn): remove duplicate longname from v1 schema field

### DIFF
--- a/modflow_devtools/dfn/schema/v1.py
+++ b/modflow_devtools/dfn/schema/v1.py
@@ -29,7 +29,6 @@ class FieldV1(Field):
     tagged: bool = False
     in_record: bool = False
     layered: bool | None = None
-    longname: str | None = None
     preserve_case: bool = False
     numeric_index: bool = False
     deprecated: bool = False


### PR DESCRIPTION
longname is already an attribute on the base field