### PR TITLE
feat(dfns): add get_block() method to ComponentBase

### DIFF
--- a/autotest/dfns/conftest.py
+++ b/autotest/dfns/conftest.py
@@ -9,8 +9,6 @@ PROJ_ROOT = Path(__file__).parents[1]
 
 DFNS_REPO = os.getenv("TEST_DFNS_REPO", "MODFLOW-ORG/modflow6")
 DFNS_REF = os.getenv("TEST_DFNS_REF", "develop")
-DFNS_SOURCE = os.getenv("TEST_DFNS_SOURCE", "modflow6")
-DFNS_VERSION = os.getenv("TEST_DFNS_VERSION", "6.6.0")
 
 
 @pytest.fixture(scope="module")

--- a/autotest/dfns/test_schema.py
+++ b/autotest/dfns/test_schema.py
@@ -171,7 +171,7 @@ def test_component_fields_duplicate_name_raises():
             "block2": Block(name="block2", fields={"a": a2}),
         },
     )
-    with pytest.raises(ValueError, match="Duplicate field name 'a'"):
+    with pytest.raises(ValueError, match="Duplicate field 'a'"):
         _ = pkg.fields
 
 

--- a/autotest/dfns/test_schema.py
+++ b/autotest/dfns/test_schema.py
@@ -175,6 +175,47 @@ def test_component_fields_duplicate_name_raises():
         _ = pkg.fields
 
 
+def test_get_block_no_blocks():
+    pkg = _pkg("gwf-chd")
+    assert pkg.get_block("nlay") is None
+
+
+def test_get_block_none_blocks():
+    pkg = Package(name="gwf-chd", blocks=None)
+    assert pkg.get_block("nlay") is None
+
+
+def test_get_block_field_not_found():
+    nlay = Integer(name="nlay")
+    pkg = _pkg(
+        "gwf-dis",
+        blocks={"dimensions": Block(name="dimensions", fields={"nlay": nlay})},
+    )
+    assert pkg.get_block("nrow") is None
+
+
+def test_get_block_found():
+    nlay = Integer(name="nlay")
+    dim_block = Block(name="dimensions", fields={"nlay": nlay})
+    pkg = _pkg("gwf-dis", blocks={"dimensions": dim_block})
+    assert pkg.get_block("nlay") is dim_block
+
+
+def test_get_block_found_in_second_block():
+    from modflow_devtools.dfns.schema import Keyword
+
+    verbose = Keyword(name="verbose", optional=True)
+    nlay = Integer(name="nlay")
+    opt_block = Block(name="options", fields={"verbose": verbose})
+    dim_block = Block(name="dimensions", fields={"nlay": nlay})
+    pkg = _pkg(
+        "gwf-dis",
+        blocks={"options": opt_block, "dimensions": dim_block},
+    )
+    assert pkg.get_block("verbose") is opt_block
+    assert pkg.get_block("nlay") is dim_block
+
+
 def test_component_fields_loaded(dfn_dir):
     spec = Dfns.load(dfn_dir)
     gwf_dis = spec.components["gwf-dis"]

--- a/modflow_devtools/dfns/schema.py
+++ b/modflow_devtools/dfns/schema.py
@@ -401,9 +401,15 @@ class ComponentBase(BaseModel):
         for block in (self.blocks or {}).values():
             for name, field in block.fields.items():
                 if name in result:
-                    raise ValueError(f"Duplicate field name {name!r} in component {self.name!r}")
+                    raise ValueError(f"Duplicate field {name!r} in component {self.name!r}")
                 result[name] = field
         return result
+
+    def get_block(self, field_name: str) -> Block | None:
+        for block in (self.blocks or {}).values():
+            if block.fields.get(field_name, None):
+                return block
+        return None
 
 
 class Simulation(ComponentBase):


### PR DESCRIPTION
Method to get the block that owns a given field. Convenience method motivated by the fact that field definitions don't specify the block they are in (to avoid redundancy).