### PR TITLE
feat(dfns): add model dependent variable info

### DIFF
--- a/autotest/dfns/test_migrate_v1_to_v2.py
+++ b/autotest/dfns/test_migrate_v1_to_v2.py
@@ -1,7 +1,7 @@
 import pytest
 
 from modflow_devtools.dfn import schema as v1
-from modflow_devtools.dfns.migrate_v1_to_v2 import _DEPENDENT_VARS
+from modflow_devtools.dfns.migrate_v1_to_v2 import _DEPENDENT_VARS, _OC_RTYPE_VALID
 from modflow_devtools.dfns.migrate_v1_to_v2 import v1_to_v2 as v1_to_v2
 from modflow_devtools.dfns.schema import (
     Double,
@@ -471,7 +471,7 @@ def _oc_dfn(prefix: str) -> v1.Dfn:
     )
 
 
-@pytest.mark.parametrize("prefix,expected", list(_DEPENDENT_VARS.items()))
+@pytest.mark.parametrize("prefix,expected", list(_OC_RTYPE_VALID.items()))
 def test_oc_rtype_valid(prefix, expected):
     component = v1_to_v2(_oc_dfn(prefix))
     assert isinstance(component, Package)
@@ -486,11 +486,14 @@ def test_oc_rtype_valid(prefix, expected):
         assert rtype.valid == expected
 
 
-@pytest.mark.parametrize(
-    "prefix,expected",
-    [(prefix, [v.lower() for v in vals]) for prefix, vals in _DEPENDENT_VARS.items()],
-)
+@pytest.mark.parametrize("prefix,expected", list(_DEPENDENT_VARS.items()))
 def test_model_dependent_variable(prefix, expected):
     result = v1_to_v2(_v1_dfn(name=f"{prefix}-nam"))
     assert isinstance(result, Model)
     assert result.dependent_variable == expected
+
+
+def test_model_no_dependent_variable():
+    result = v1_to_v2(_v1_dfn(name="prt-nam"))
+    assert isinstance(result, Model)
+    assert result.dependent_variable is None

--- a/autotest/dfns/test_migrate_v1_to_v2.py
+++ b/autotest/dfns/test_migrate_v1_to_v2.py
@@ -1,5 +1,7 @@
+import pytest
+
 from modflow_devtools.dfn import schema as v1
-from modflow_devtools.dfns.migrate_v1_to_v2 import v1_to_v2 as v1_to_v2
+from modflow_devtools.dfns.migrate_v1_to_v2 import _DEPENDENT_VARS, v1_to_v2 as v1_to_v2
 from modflow_devtools.dfns.schema import (
     Double,
     FieldBase,
@@ -10,6 +12,7 @@ from modflow_devtools.dfns.schema import (
     Record,
     Simulation,
     String,
+    Union,
 )
 
 
@@ -425,3 +428,67 @@ def test_components():
     result = v1_to_v2(dfn)
     assert isinstance(result, Package)
     assert result.subtype == "advanced"
+
+
+def _oc_dfn(prefix: str) -> v1.Dfn:
+    """Minimal OC-like v1 DFN for testing rtype.valid migration."""
+    return _v1_dfn(
+        name=f"{prefix}-oc",
+        parent=f"{prefix}-nam",
+        blocks={
+            "period": {
+                "saverecord": _v1_field(
+                    name="saverecord",
+                    type="record save rtype ocsetting",
+                    block="period",
+                    optional=True,
+                ),
+                "save": _v1_field(name="save", type="keyword", block="period", in_record=True),
+                "printrecord": _v1_field(
+                    name="printrecord",
+                    type="record print rtype ocsetting",
+                    block="period",
+                    optional=True,
+                ),
+                "print": _v1_field(name="print", type="keyword", block="period", in_record=True),
+                "rtype": _v1_field(
+                    name="rtype",
+                    type="string",
+                    block="period",
+                    in_record=True,
+                    tagged=False,
+                ),
+                "ocsetting": _v1_field(
+                    name="ocsetting",
+                    type="keystring all",
+                    block="period",
+                    in_record=True,
+                ),
+                "all": _v1_field(name="all", type="keyword", block="period", in_record=True),
+            }
+        },
+    )
+
+
+@pytest.mark.parametrize("prefix,expected", list(_DEPENDENT_VARS.items()))
+def test_oc_rtype_valid(prefix, expected):
+    component = v1_to_v2(_oc_dfn(prefix))
+    assert isinstance(component, Package)
+    period = component.blocks["period"]
+    output = period.fields["output"]
+    assert isinstance(output, List)
+    assert isinstance(output.item, Union)
+    for arm in output.item.arms.values():
+        assert isinstance(arm, Record)
+        rtype = arm.fields["rtype"]
+        assert isinstance(rtype, String)
+        assert rtype.valid == expected
+
+
+@pytest.mark.parametrize("prefix,expected", [
+    (prefix, [v.lower() for v in vals]) for prefix, vals in _DEPENDENT_VARS.items()
+])
+def test_model_dependent_variable(prefix, expected):
+    result = v1_to_v2(_v1_dfn(name=f"{prefix}-nam"))
+    assert isinstance(result, Model)
+    assert result.dependent_variable == expected

--- a/autotest/dfns/test_migrate_v1_to_v2.py
+++ b/autotest/dfns/test_migrate_v1_to_v2.py
@@ -1,7 +1,8 @@
 import pytest
 
 from modflow_devtools.dfn import schema as v1
-from modflow_devtools.dfns.migrate_v1_to_v2 import _DEPENDENT_VARS, v1_to_v2 as v1_to_v2
+from modflow_devtools.dfns.migrate_v1_to_v2 import _DEPENDENT_VARS
+from modflow_devtools.dfns.migrate_v1_to_v2 import v1_to_v2 as v1_to_v2
 from modflow_devtools.dfns.schema import (
     Double,
     FieldBase,
@@ -485,9 +486,10 @@ def test_oc_rtype_valid(prefix, expected):
         assert rtype.valid == expected
 
 
-@pytest.mark.parametrize("prefix,expected", [
-    (prefix, [v.lower() for v in vals]) for prefix, vals in _DEPENDENT_VARS.items()
-])
+@pytest.mark.parametrize(
+    "prefix,expected",
+    [(prefix, [v.lower() for v in vals]) for prefix, vals in _DEPENDENT_VARS.items()],
+)
 def test_model_dependent_variable(prefix, expected):
     result = v1_to_v2(_v1_dfn(name=f"{prefix}-nam"))
     assert isinstance(result, Model)

--- a/docs/md/dfnspec.md
+++ b/docs/md/dfnspec.md
@@ -16,6 +16,7 @@ This document describes the MODFLOW 6 component definition (DFN) system. This sy
     - [Model](#model)
       - [Type-specific attributes](#type-specific-attributes)
         - [`solution`](#solution)
+        - [`dependent_variable`](#dependent_variable)
     - [Package](#package)
       - [Type-specific attributes](#type-specific-attributes-1)
         - [`multi`](#multi)
@@ -159,6 +160,10 @@ A model represents a hydrologic process. Models are managed and solved by the si
 ###### `solution`
 
 `"ims" | "ems" | "sln-ims" | "sln-ems" | null (default: null)`. MF6 supports different solution schemes: implicit solutions (solve systems of coupled equations iteratively) and explicit solutions (used when closed-form solutions are available). A model declares which solution type it requires with the optional `solution` attribute. Solution packages do not redundantly declare which model types they support; compatibility is determined entirely from the model side.
+
+###### `dependent_variable`
+
+`[string] (default: [])`. The dependent variables this model type computes, declared in lowercase — e.g., `["head", "budget"]` for GWF. The model's OC package enumerates the same values as the `valid` set on its `rtype` string field.
 
 #### Package
 

--- a/docs/md/dfnspec.md
+++ b/docs/md/dfnspec.md
@@ -163,7 +163,7 @@ A model represents a hydrologic process. Models are managed and solved by the si
 
 ###### `dependent_variable`
 
-`[string] (default: [])`. The dependent variables this model type computes, declared in lowercase — e.g., `["head", "budget"]` for GWF. The model's OC package enumerates the same values as the `valid` set on its `rtype` string field.
+`string | null (default: null)`. The dependent variable this model type computes, e.g. `"head"` for GWF. The model's OC package `rtype` string field should also specify this variable's name as a `valid` value.
 
 #### Package
 

--- a/modflow_devtools/dfns/__init__.py
+++ b/modflow_devtools/dfns/__init__.py
@@ -21,10 +21,10 @@ from modflow_devtools.dfns.schema import (
     Model,
     Package,
     Record,
+    Scalar,
     Simulation,
     String,
     Union,
-    Scalar,
 )
 
 # Experimental API warning
@@ -58,9 +58,9 @@ __all__ = [
     "Package",
     "Record",
     "RemoteDfnRegistry",
+    "Scalar",
     "Simulation",
     "String",
-    "Scalar",
     "Union",
     "fetch_dfns",
     "migrate",

--- a/modflow_devtools/dfns/__init__.py
+++ b/modflow_devtools/dfns/__init__.py
@@ -24,6 +24,7 @@ from modflow_devtools.dfns.schema import (
     Simulation,
     String,
     Union,
+    Scalar,
 )
 
 # Experimental API warning
@@ -59,6 +60,7 @@ __all__ = [
     "RemoteDfnRegistry",
     "Simulation",
     "String",
+    "Scalar",
     "Union",
     "fetch_dfns",
     "migrate",

--- a/modflow_devtools/dfns/migrate_v1_to_v2.py
+++ b/modflow_devtools/dfns/migrate_v1_to_v2.py
@@ -10,6 +10,16 @@ from modflow_devtools.misc import try_literal_eval
 _IDENT_RE = re.compile(r"^[A-Za-z_]\w*$")
 _LOOKUP_RE = re.compile(r"^(\w+)\.(\w+)\((\w+)\)$")
 
+_DEPENDENT_VARS: dict[str, list[str]] = {
+    "gwf": ["HEAD", "BUDGET"],
+    "gwt": ["CONCENTRATION", "BUDGET"],
+    "gwe": ["TEMPERATURE", "BUDGET"],
+    "chf": ["BUDGET"],
+    "olf": ["BUDGET"],
+    "swf": ["BUDGET"],
+    "prt": ["BUDGET"],
+}
+
 
 def _scope_for(
     parent: "str | list[str] | None",
@@ -345,6 +355,61 @@ def _collapse_sto_keywords(
             valid=["steady-state", "transient"],
         )
         result[bname] = block.model_copy(update={"fields": {**non_sto, "storage": storage}})
+    return result
+
+
+def _patch_oc_rtype(
+    name: str,
+    blocks: dict[str, v2.Block],
+) -> dict[str, v2.Block]:
+    """Set valid values on rtype string fields in OC packages."""
+    if not name.endswith("-oc"):
+        return blocks
+    prefix = name.split("-")[0]
+    valid = _DEPENDENT_VARS.get(prefix)
+    if not valid:
+        return blocks
+
+    def _patch(fields: dict) -> tuple[dict, bool]:
+        new_fields = {}
+        changed = False
+        for fname, field in fields.items():
+            if isinstance(field, v2.String) and fname == "rtype":
+                field = field.model_copy(update={"valid": valid})
+                changed = True
+            elif isinstance(field, v2.Record):
+                patched, c = _patch(field.fields)
+                if c:
+                    field = field.model_copy(update={"fields": patched})
+                    changed = True
+            elif isinstance(field, v2.Union):
+                patched, c = _patch(field.arms)
+                if c:
+                    field = field.model_copy(update={"arms": patched})
+                    changed = True
+            elif isinstance(field, v2.List):
+                item = field.item
+                if isinstance(item, v2.Record):
+                    patched, c = _patch(item.fields)
+                    if c:
+                        field = field.model_copy(
+                            update={"item": item.model_copy(update={"fields": patched})}
+                        )
+                        changed = True
+                elif isinstance(item, v2.Union):
+                    patched, c = _patch(item.arms)
+                    if c:
+                        field = field.model_copy(
+                            update={"item": item.model_copy(update={"arms": patched})}
+                        )
+                        changed = True
+            new_fields[fname] = field
+        return new_fields, changed
+
+    result = {}
+    for bname, block in blocks.items():
+        new_fields, changed = _patch(block.fields)
+        result[bname] = block.model_copy(update={"fields": new_fields}) if changed else block
     return result
 
 
@@ -754,6 +819,7 @@ def v1_to_v2(dfn: v1.Dfn) -> v2.Component:
     blocks = _fill_period_list_shapes(blocks, explicit_dims)
     blocks = _wrap_oc_period_records(blocks)
     blocks = _collapse_sto_keywords(blocks)
+    blocks = _patch_oc_rtype(name, blocks)
     dims = {**explicit_dims, **array_dims} or None
 
     d: dict[str, Any] = {
@@ -766,7 +832,9 @@ def v1_to_v2(dfn: v1.Dfn) -> v2.Component:
     if name == "sim-nam":
         return v2.Simulation(**d)
     if name.endswith("-nam"):
-        return v2.Model(**d)
+        prefix = name.split("-")[0]
+        dep_vars = [v.lower() for v in _DEPENDENT_VARS.get(prefix, [])]
+        return v2.Model(**d, dependent_variable=dep_vars)
 
     subtype: Literal["solution", "exchange", "stress", "advanced", "utility"] | None = None
     if name.startswith("sln-"):

--- a/modflow_devtools/dfns/migrate_v1_to_v2.py
+++ b/modflow_devtools/dfns/migrate_v1_to_v2.py
@@ -10,13 +10,23 @@ from modflow_devtools.misc import try_literal_eval
 _IDENT_RE = re.compile(r"^[A-Za-z_]\w*$")
 _LOOKUP_RE = re.compile(r"^(\w+)\.(\w+)\((\w+)\)$")
 
-_DEPENDENT_VARS: dict[str, list[str]] = {
+_DEPENDENT_VARS: dict[str, str] = {
+    "gwf": "head",
+    "gwt": "concentration",
+    "gwe": "temperature",
+    "chf": "stage",
+    "olf": "stage",
+    "swf": "stage",
+    # prt: particle tracking; no scalar dependent variable
+}
+
+_OC_RTYPE_VALID: dict[str, list[str]] = {
     "gwf": ["HEAD", "BUDGET"],
     "gwt": ["CONCENTRATION", "BUDGET"],
     "gwe": ["TEMPERATURE", "BUDGET"],
-    "chf": ["BUDGET"],
-    "olf": ["BUDGET"],
-    "swf": ["BUDGET"],
+    "chf": ["STAGE", "BUDGET"],
+    "olf": ["STAGE", "BUDGET"],
+    "swf": ["STAGE", "BUDGET"],
     "prt": ["BUDGET"],
 }
 
@@ -366,7 +376,7 @@ def _patch_oc_rtype(
     if not name.endswith("-oc"):
         return blocks
     prefix = name.split("-")[0]
-    valid = _DEPENDENT_VARS.get(prefix)
+    valid = _OC_RTYPE_VALID.get(prefix)
     if not valid:
         return blocks
 
@@ -833,8 +843,7 @@ def v1_to_v2(dfn: v1.Dfn) -> v2.Component:
         return v2.Simulation(**d)
     if name.endswith("-nam"):
         prefix = name.split("-")[0]
-        dep_vars = [v.lower() for v in _DEPENDENT_VARS.get(prefix, [])]
-        return v2.Model(**d, dependent_variable=dep_vars)
+        return v2.Model(**d, dependent_variable=_DEPENDENT_VARS.get(prefix))
 
     subtype: Literal["solution", "exchange", "stress", "advanced", "utility"] | None = None
     if name.startswith("sln-"):

--- a/modflow_devtools/dfns/schema.py
+++ b/modflow_devtools/dfns/schema.py
@@ -413,6 +413,7 @@ class Simulation(ComponentBase):
 class Model(ComponentBase):
     type: Literal["model"] = "model"
     solution: Literal["ims", "ems", "sln-ims", "sln-ems"] | None = None
+    dependent_variable: list[str] = []
 
 
 class Package(ComponentBase):

--- a/modflow_devtools/dfns/schema.py
+++ b/modflow_devtools/dfns/schema.py
@@ -413,7 +413,7 @@ class Simulation(ComponentBase):
 class Model(ComponentBase):
     type: Literal["model"] = "model"
     solution: Literal["ims", "ems", "sln-ims", "sln-ems"] | None = None
-    dependent_variable: list[str] = []
+    dependent_variable: str | None = None
 
 
 class Package(ComponentBase):


### PR DESCRIPTION
Add a `dependent_variable` attribute to `Model`, so a model may declare a dependent variable it solves for. This becomes an acceptable option for OC period data `rtype` (plus "budget", common to all model types), which can be validated at runtime via the `valid` value mechanism.