### PR TITLE
refactor(dfns): better dim specification

### DIFF
--- a/autotest/dfns/test_schema_dimensions.py
+++ b/autotest/dfns/test_schema_dimensions.py
@@ -48,6 +48,18 @@ def test_names_in_expr_excludes_sum_func_name_itself():
     assert "sum" not in names
 
 
+def test_names_in_expr_excludes_builtin_func_name():
+    assert _names_in_expr("abs(nlay)") == {"nlay"}
+    assert _names_in_expr("min(nlay, ncol)") == {"nlay", "ncol"}
+    assert _names_in_expr("round(nlay)") == {"nlay"}
+
+
+def test_names_in_expr_excludes_qualified_func_name():
+    # math.floor(nlay): 'math' is a Name inside the Attribute func, not a dim ref
+    assert _names_in_expr("math.floor(nlay)") == {"nlay"}
+    assert _names_in_expr("math.ceil(nrow * 2)") == {"nrow"}
+
+
 def test_names_in_expr_invalid_syntax():
     with pytest.raises(ValueError, match="Invalid expression"):
         _names_in_expr("nlay * (")

--- a/autotest/dfns/test_schema_dimensions.py
+++ b/autotest/dfns/test_schema_dimensions.py
@@ -18,6 +18,7 @@ from modflow_devtools.dfns.schema import (
     String,
     _names_in_expr,
     _resolve_derived_dims,
+    _validate_len_call,
     _validate_shape_element,
     _validate_sum_call,
 )
@@ -57,8 +58,8 @@ def test_shape_expr_cyclic_resolution():
         name="bad",
         blocks=None,
         dims={
-            "a": Dim(expr="b + 1", scope="component"),
-            "b": Dim(expr="a + 1", scope="component"),
+            "a": Dim(value="b + 1", scope="component"),
+            "b": Dim(value="a + 1", scope="component"),
         },
     )
     with pytest.raises(ValueError, match="Cycle in"):
@@ -69,7 +70,7 @@ def test_shape_expr_unknown_operand():
     pkg = Package(
         name="bad",
         blocks=None,
-        dims={"nodes": Dim(expr="ghost_dim * 2", scope="component")},
+        dims={"nodes": Dim(value="ghost_dim * 2", scope="component")},
     )
     with pytest.raises(ValueError, match="not a known dimension"):
         Dfns(components={"bad": pkg})
@@ -88,7 +89,7 @@ def test_resolve_derived_dims_sum_expr():
     pkg = Package(
         name="test",
         blocks=pkg.blocks,
-        dims={"total_conn": Dim(expr="sum(packagedata.nlakeconn)", scope="component")},
+        dims={"total_conn": Dim(value="sum(packagedata.nlakeconn)", scope="component")},
     )
     order = _resolve_derived_dims(pkg, set())
     assert order == ["total_conn"]
@@ -104,8 +105,8 @@ def test_resolve_derived_dims_cycle_error():
         name="test",
         blocks=None,
         dims={
-            "a": Dim(expr="b + 1", scope="component"),
-            "b": Dim(expr="a + 1", scope="component"),
+            "a": Dim(value="b + 1", scope="component"),
+            "b": Dim(value="a + 1", scope="component"),
         },
     )
     with pytest.raises(ValueError, match="Cycle in"):
@@ -116,7 +117,7 @@ def test_resolve_derived_dims_unknown_operand_error():
     pkg = Package(
         name="test",
         blocks=None,
-        dims={"nodes": Dim(expr="mystery_dim * 2", scope="component")},
+        dims={"nodes": Dim(value="mystery_dim * 2", scope="component")},
     )
     with pytest.raises(ValueError, match="not a known dimension"):
         _resolve_derived_dims(pkg, set())
@@ -126,7 +127,7 @@ def test_resolve_derived_dims_invalid_expression_error():
     pkg = Package(
         name="test",
         blocks=None,
-        dims={"nodes": Dim(expr="nlay * (", scope="component")},
+        dims={"nodes": Dim(value="nlay * (", scope="component")},
     )
     with pytest.raises(ValueError, match="Invalid"):
         _resolve_derived_dims(pkg, set())
@@ -172,6 +173,74 @@ def test_validate_sum_expr():
         _validate_sum_call(call, pkg, "sum(packagedata.nosuchcol)")
 
 
+def _make_len_call(expr: str):
+    tree = ast.parse(expr, mode="eval")
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            return node
+    raise AssertionError("No Call node found")
+
+
+def test_validate_len_call():
+    arr = Array(name="auxiliary", dtype="string", shape=[])
+    block = Block(name="options", fields={"auxiliary": arr})
+    pkg = Package(name="test", blocks={"options": block})
+
+    call = _make_len_call("len(auxiliary)")
+    _validate_len_call(call, pkg, "len(auxiliary)")  # no error
+
+    # too many arguments
+    with pytest.raises(ValueError, match="exactly one argument"):
+        bad = ast.parse("len(a, b)", mode="eval").body  # type: ignore[attr-defined]
+        _validate_len_call(bad, pkg, "len(a, b)")
+
+    # non-name argument
+    with pytest.raises(ValueError, match="field name"):
+        bad = ast.parse("len(a.b)", mode="eval").body  # type: ignore[attr-defined]
+        _validate_len_call(bad, pkg, "len(a.b)")
+
+
+def test_names_in_expr_excludes_len_internals():
+    assert _names_in_expr("len(auxiliary)") == set()
+
+
+def test_names_in_expr_len_and_arithmetic():
+    assert _names_in_expr("len(auxiliary) + nlay") == {"nlay"}
+
+
+def test_dim_value_len_form():
+    arr = Array(name="auxiliary", dtype="string", shape=[])
+    block = Block(name="options", fields={"auxiliary": arr})
+    pkg = Package(
+        name="test",
+        blocks={"options": block},
+        dims={"auxiliary": Dim(value="len(auxiliary)", scope="component")},
+    )
+    Dfns(components={"test": pkg})  # no error
+
+
+def test_dim_value_integer_field_not_found():
+    pkg = Package(
+        name="test",
+        blocks=None,
+        dims={"nlay": Dim(value="nlay", scope="component")},
+    )
+    with pytest.raises(ValueError, match="not found in component"):
+        Dfns(components={"test": pkg})
+
+
+def test_dim_value_array_field_requires_len():
+    arr = Array(name="auxiliary", dtype="string", shape=[])
+    block = Block(name="options", fields={"auxiliary": arr})
+    pkg = Package(
+        name="test",
+        blocks={"options": block},
+        dims={"auxiliary": Dim(value="auxiliary", scope="component")},
+    )
+    with pytest.raises(ValueError, match="use len\\(auxiliary\\)"):
+        Dfns(components={"test": pkg})
+
+
 def _dim_block(*names: str) -> Block:
     return Block(
         name="dimensions",
@@ -181,9 +250,9 @@ def _dim_block(*names: str) -> Block:
 
 def _make_shape_validation_ctx(dim_names: set[str], derived: dict | None = None):
     """Return (array, component, known_dims) for shape element tests."""
-    dims: dict[str, Dim] = {n: Dim(field=n, scope="component") for n in dim_names}
+    dims: dict[str, Dim] = {n: Dim(value=n, scope="component") for n in dim_names}
     if derived:
-        dims.update({n: Dim(expr=e, scope="component") for n, e in derived.items()})
+        dims.update({n: Dim(value=e, scope="component") for n, e in derived.items()})
     blocks = {"dimensions": _dim_block(*dim_names)} if dim_names else None
     pkg = Package(name="test", blocks=blocks, dims=dims or None)
     gwf = Model(name="gwf-nam", blocks=None)
@@ -204,7 +273,7 @@ def test_validate_shape_element_inherited_dim():
         name="gwf-dis",
         parent="gwf-nam",
         blocks=None,
-        dims={"nodes": Dim(expr="42", scope="model")},
+        dims={"nodes": Dim(value="42", scope="model")},
     )
     test_pkg = Package(name="gwf-test", parent="gwf-nam", blocks=None)
     gwf = Model(name="gwf-nam", blocks=None)
@@ -388,9 +457,9 @@ def test_local_dims():
         name="gwf-dis",
         blocks={"dimensions": block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
         },
     )
     spec = Dfns(components={"gwf-dis": pkg})
@@ -405,7 +474,7 @@ def test_local_dims():
     pkg3 = Package(
         name="test",
         blocks=None,
-        dims={"nodes": Dim(expr="42", scope="component")},
+        dims={"nodes": Dim(value="42", scope="component")},
     )
     spec3 = Dfns(components={"test": pkg3})
     assert spec3.local_dims("test") == {"nodes"}
@@ -417,24 +486,24 @@ def test_resolve_derived_dims():
         name="test",
         blocks={"dimensions": block},
         dims={
-            "nlay": Dim(field="nlay", scope="component"),
-            "nrow": Dim(field="nrow", scope="component"),
-            "ncol": Dim(field="ncol", scope="component"),
-            "nodes": Dim(expr="nlay * nrow * ncol", scope="component"),
+            "nlay": Dim(value="nlay", scope="component"),
+            "nrow": Dim(value="nrow", scope="component"),
+            "ncol": Dim(value="ncol", scope="component"),
+            "nodes": Dim(value="nlay * nrow * ncol", scope="component"),
         },
     )
     order = _resolve_derived_dims(pkg, {"nlay", "nrow", "ncol"})
-    assert order == ["nodes"]
+    assert order[-1] == "nodes"  # nodes depends on the three field-backed dims
 
     pkg = Package(
         name="test",
         blocks={"dimensions": block},
         dims={
-            "nlay": Dim(field="nlay", scope="component"),
-            "nrow": Dim(field="nrow", scope="component"),
-            "ncol": Dim(field="ncol", scope="component"),
-            "nodes": Dim(expr="nlay * nrow * ncol", scope="component"),
-            "nodouble": Dim(expr="nodes * 2", scope="component"),
+            "nlay": Dim(value="nlay", scope="component"),
+            "nrow": Dim(value="nrow", scope="component"),
+            "ncol": Dim(value="ncol", scope="component"),
+            "nodes": Dim(value="nlay * nrow * ncol", scope="component"),
+            "nodouble": Dim(value="nodes * 2", scope="component"),
         },
     )
     order = _resolve_derived_dims(pkg, {"nlay", "nrow", "ncol"})
@@ -443,7 +512,7 @@ def test_resolve_derived_dims():
     pkg = Package(
         name="test",
         blocks=None,
-        dims={"derived": Dim(expr="nodes + 1", scope="component")},
+        dims={"derived": Dim(value="nodes + 1", scope="component")},
     )
     order = _resolve_derived_dims(pkg, {"nodes"})
     assert order == ["derived"]
@@ -455,10 +524,10 @@ def test_dim_validation():
         name="gwf-dis",
         blocks={"dimensions": block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
-            "nodes": Dim(expr="nlay * nrow * ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
+            "nodes": Dim(value="nlay * nrow * ncol", scope="model"),
         },
     )
     spec = Dfns(components={"gwf-dis": pkg})
@@ -475,9 +544,9 @@ def test_local_dims_model_scoped():
         name="gwf-dis",
         blocks={"dimensions": block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
         },
     )
     spec = Dfns(components={"gwf-dis": pkg})
@@ -491,10 +560,10 @@ def test_inherited_dims():
         parent="gwf-nam",
         blocks={"dimensions": dis_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
-            "nodes": Dim(expr="nlay * nrow * ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
+            "nodes": Dim(value="nlay * nrow * ncol", scope="model"),
         },
     )
     chd = _pkg("gwf-chd", parent="gwf-nam", blocks=None)
@@ -513,8 +582,8 @@ def test_inherited_dims():
         parent="gwf-nam",
         blocks={"dimensions": disv_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "ncpl": Dim(field="ncpl", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "ncpl": Dim(value="ncpl", scope="model"),
         },
     )
     chd = _pkg("gwf-chd", parent="gwf-nam", blocks=None)
@@ -531,8 +600,8 @@ def test_inherited_dims():
         parent="gwf-nam",
         blocks={"dimensions": disu_block},
         dims={
-            "nodes": Dim(field="nodes", scope="model"),
-            "nja": Dim(field="nja", scope="model"),
+            "nodes": Dim(value="nodes", scope="model"),
+            "nja": Dim(value="nja", scope="model"),
         },
     )
     chd = _pkg("gwf-chd", parent="gwf-nam", blocks=None)
@@ -551,16 +620,16 @@ def test_inherited_dims_excludes_own():
         parent="gwf-nam",
         blocks={"dimensions": dis_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
         },
     )
     chd = Package(
         name="gwf-chd",
         parent="gwf-nam",
         blocks={"dimensions": _dim_block("secret_dim")},
-        dims={"secret_dim": Dim(field="secret_dim", scope="model")},
+        dims={"secret_dim": Dim(value="secret_dim", scope="model")},
     )
     gwf = Model(name="gwf-nam", blocks=None)
     spec = Dfns(components={"gwf-nam": gwf, "gwf-dis": dis, "gwf-chd": chd})
@@ -578,10 +647,10 @@ def _dis_dfns() -> Dfns:
         parent="gwf-nam",
         blocks={"dimensions": dis_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
-            "nodes": Dim(expr="nlay * nrow * ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
+            "nodes": Dim(value="nlay * nrow * ncol", scope="model"),
         },
     )
     return Dfns(components={"gwf-nam": gwf, "gwf-dis": dis})
@@ -601,10 +670,10 @@ def test_dims_includes_derived():
         parent="gwf-nam",
         blocks={"dimensions": dis_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
-            "nodes": Dim(expr="nlay * nrow * ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
+            "nodes": Dim(value="nlay * nrow * ncol", scope="model"),
         },
     )
     spec = Dfns(components={"gwf-nam": gwf, "gwf-dis": dis})
@@ -630,9 +699,9 @@ def test_top_level_array():
         parent="gwf-nam",
         blocks={"dimensions": dis_block, "griddata": grid_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
         },
     )
     gwf = Model(name="gwf-nam", blocks=None)
@@ -650,9 +719,9 @@ def test_array_in_record():
         parent="gwf-nam",
         blocks={"dimensions": dis_block, "options": opt_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
         },
     )
     gwf = Model(name="gwf-nam", blocks=None)
@@ -690,9 +759,9 @@ def test_invalid_array_shape():
         parent="gwf-nam",
         blocks={"dimensions": dis_block, "griddata": grid_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
         },
     )
     gwf = Model(name="gwf-nam", blocks=None)
@@ -709,10 +778,10 @@ def test_array_shape_resolves_via_derived_dim():
         parent="gwf-nam",
         blocks={"dimensions": dis_block, "griddata": grid_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
-            "nodes": Dim(expr="nlay * nrow * ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
+            "nodes": Dim(value="nlay * nrow * ncol", scope="model"),
         },
     )
     gwf = Model(name="gwf-nam", blocks=None)
@@ -727,10 +796,10 @@ def test_array_shape_resolves_sibling_dims():
         parent="gwf-nam",
         blocks={"dimensions": dis_block},
         dims={
-            "nlay": Dim(field="nlay", scope="model"),
-            "nrow": Dim(field="nrow", scope="model"),
-            "ncol": Dim(field="ncol", scope="model"),
-            "nodes": Dim(expr="nlay * nrow * ncol", scope="model"),
+            "nlay": Dim(value="nlay", scope="model"),
+            "nrow": Dim(value="nrow", scope="model"),
+            "ncol": Dim(value="ncol", scope="model"),
+            "nodes": Dim(value="nlay * nrow * ncol", scope="model"),
         },
     )
     chd_arr = Array(name="head", dtype="double", shape=["nlay", "nodes"])

--- a/docs/md/dfnspec.md
+++ b/docs/md/dfnspec.md
@@ -141,7 +141,7 @@ Parent relationships are defined bottom-up with attribute `parent`:
 
 #### `dims`
 
-`{string: Dim} (default: {})`. Named dimensions available for use in array and list shape expressions. Each entry is either field-backed (`field`: the name of an integer or self-sizing array field in this component) or derived (`expr`: an arithmetic expression over other dims), plus a `scope` that controls visibility to other components. See [Dimensions](#dimensions).
+`{string: Dim} (default: {})`. Named dimensions available for use in array and list shape expressions. Each entry has a `value` expression and a `scope` that controls visibility to other components. See [Dimensions](#dimensions).
 
 ### Component types
 
@@ -471,30 +471,35 @@ A **non-empty `shape`** (exactly one element) names a declared dimension that bo
 
 ### Dimensions
 
-Dimensions may be declared by a component with a `dims` map. Each entry in `dims` consists of a **source** (a field or an expression combining other dimension fields) and a **scope**:
+Dimensions may be declared by a component with a `dims` map. Each entry in `dims` has a `value` expression and a `scope`:
 
 ```yaml
 dims:
   nlay:
-    field: nlay        # backed by a sibling integer field 'nlay'
+    value: nlay                  # backed by integer field 'nlay'
     scope: model
   nodes:
-    expr: "nlay * nrow * ncol"   # derived from other dims
+    value: "nlay * nrow * ncol"  # derived from other dims
     scope: model
   nper:
-    field: nper
+    value: nper
     scope: simulation
+  auxiliary:
+    value: "len(auxiliary)"      # backed by self-sizing array field 'auxiliary'
+    scope: component
 ```
 
 Dimensions may be used in the `shape` expression of `list` and `array` fields.
 
 #### Dimension sources
 
-The `field` and `expr` attributes define dimension sources. These attributes are mutually exclusive, distinguishing **explicit dimensions** from **derived dimensions**.
+The `value` attribute defines the dimension source as a Python expression. Three forms are distinguished:
 
-Explicit dimensions are most straightforwardly defined with an `integer` field, directly indicating the size of the dimension. Self-sizing `array` fields may also may serve as explicit dimension sources; a self-sizing array dimension is effectively a dynamic dimension size, indicating "the same size as this array".
+- **Bare identifier** `nlay` — backed by an integer field of that name in this component. The dimension takes the runtime value of that field.
+- **`len(name)`** — backed by a self-sizing array field of that name. The dimension equals the runtime length of the array.
+- **Arithmetic expression** `nlay * nrow * ncol` — derived from other dims. May not use bare field names; all operands must be declared dimensions.
 
-A dimension with an `expr` attribute rather than `field` is a derived dimension. Shape expressions use Python-like syntax and may contain several kinds of reference, resolved in the order presented below:
+Shape expressions use Python-like syntax and may contain several kinds of reference, resolved in the order presented below:
 
 - **Local dimension**: an explicit or derived dimension in this component, resolved in dependency order.
 - **Inherited dimension**: a dimension inherited from another component, per scoping rules (see below).
@@ -508,20 +513,23 @@ Canonical examples of dimensions:
 ```yaml
 dims:
   # sim-tdis
-  nper: {field: nper, scope: simulation}
+  nper: {value: nper, scope: simulation}
 
   # gwf-dis
-  nlay: {field: nlay, scope: model}
-  nrow: {field: nrow, scope: model}
-  ncol: {field: ncol, scope: model}
-  ncpl: {expr: "nrow * ncol", scope: model}
-  nodes: {expr: "nlay * nrow * ncol", scope: model}
-  ncelldim: {expr: "3", scope: model}
+  nlay: {value: nlay, scope: model}
+  nrow: {value: nrow, scope: model}
+  ncol: {value: ncol, scope: model}
+  ncpl: {value: "nrow * ncol", scope: model}
+  nodes: {value: "nlay * nrow * ncol", scope: model}
+  ncelldim: {value: "3", scope: model}
 
   # gwf-disv
-  ncpl: {field: ncpl, scope: model}
-  nodes: {expr: "nlay * ncpl", scope: model}
-  ncelldim: {expr: "2", scope: model}
+  ncpl: {value: ncpl, scope: model}
+  nodes: {value: "nlay * ncpl", scope: model}
+  ncelldim: {value: "2", scope: model}
+
+  # any package with an auxiliary array
+  auxiliary: {value: "len(auxiliary)"}
 ```
 
 An inline array may have its size determined by an integer subfield in the same record, or if the record it is within is the item type of a list, by a column in another list.

--- a/modflow_devtools/dfns/migrate_v1_to_v2.py
+++ b/modflow_devtools/dfns/migrate_v1_to_v2.py
@@ -117,23 +117,23 @@ def _build_explicit_dims(
     scope = _scope_for(parent)
     for fname, field in dim_block.fields.items():
         if isinstance(field, v2.Integer):
-            dims[fname] = v2.Dim(field=fname, scope=scope)
+            dims[fname] = v2.Dim(value=fname, scope=scope)
 
     if scope == "model":
         has = set(dims.keys())
         if {"nlay", "nrow", "ncol"} <= has:
-            dims["ncpl"] = v2.Dim(expr="nrow * ncol", scope="model")
-            dims["nodes"] = v2.Dim(expr="nlay * nrow * ncol", scope="model")
-            dims["ncelldim"] = v2.Dim(expr="3", scope="model")
+            dims["ncpl"] = v2.Dim(value="nrow * ncol", scope="model")
+            dims["nodes"] = v2.Dim(value="nlay * nrow * ncol", scope="model")
+            dims["ncelldim"] = v2.Dim(value="3", scope="model")
         elif {"nlay", "ncpl"} <= has:
-            dims["nodes"] = v2.Dim(expr="nlay * ncpl", scope="model")
-            dims["ncelldim"] = v2.Dim(expr="2", scope="model")
+            dims["nodes"] = v2.Dim(value="nlay * ncpl", scope="model")
+            dims["ncelldim"] = v2.Dim(value="2", scope="model")
         elif {"nrow", "ncol"} <= has:
-            dims["ncpl"] = v2.Dim(expr="nrow * ncol", scope="model")
-            dims["nodes"] = v2.Dim(expr="nrow * ncol", scope="model")
-            dims["ncelldim"] = v2.Dim(expr="2", scope="model")
+            dims["ncpl"] = v2.Dim(value="nrow * ncol", scope="model")
+            dims["nodes"] = v2.Dim(value="nrow * ncol", scope="model")
+            dims["ncelldim"] = v2.Dim(value="2", scope="model")
         elif "nodes" in has:
-            dims["ncelldim"] = v2.Dim(expr="1", scope="model")
+            dims["ncelldim"] = v2.Dim(value="1", scope="model")
 
     return dims
 
@@ -199,7 +199,7 @@ def _resolve_dimensions(
         _scan(block.fields)
 
     array_dim_names = self_sizing & shape_refs
-    array_dims = {n: v2.Dim(field=n, scope="component") for n in array_dim_names}
+    array_dims = {n: v2.Dim(value=f"len({n})", scope="component") for n in array_dim_names}
     return blocks, array_dims
 
 

--- a/modflow_devtools/dfns/schema.py
+++ b/modflow_devtools/dfns/schema.py
@@ -155,23 +155,27 @@ List.model_rebuild()
 
 
 def _names_in_expr(expr: str) -> set[str]:
-    """Return Name identifiers from expr, excluding those inside sum() calls."""
+    """Return Name identifiers from expr, excluding those inside sum() or len() calls."""
     try:
         tree = ast.parse(expr, mode="eval")
     except SyntaxError as e:
         raise ValueError(f"Invalid expression {expr!r}: {e}") from e
 
-    sum_interior_ids: set[int] = set()
+    excluded_ids: set[int] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "sum":
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in ("sum", "len")
+        ):
             for child in ast.walk(node):
                 if child is not node:
-                    sum_interior_ids.add(id(child))
+                    excluded_ids.add(id(child))
 
     return {
         node.id
         for node in ast.walk(tree)
-        if isinstance(node, ast.Name) and id(node) not in sum_interior_ids
+        if isinstance(node, ast.Name) and id(node) not in excluded_ids
     }
 
 
@@ -223,22 +227,25 @@ def _validate_sum_call(call: ast.Call, component: "ComponentBase", expr: str) ->
         )
 
 
+def _validate_len_call(call: ast.Call, component: "ComponentBase", expr: str) -> None:
+    """Validate a len(field_name) call in a dims value expression."""
+    if len(call.args) != 1:
+        raise ValueError(f"len() in dims must have exactly one argument in {expr!r}")
+    if not isinstance(call.args[0], ast.Name):
+        raise ValueError(f"len() argument must be a field name in {expr!r}")
+
+
 class Dim(BaseModel):
-    """A named dimension, either backed by a field or derived from an expression."""
+    """A named dimension backed by a field reference or derived from an expression.
 
-    field: str | None = None  # name of the field that provides this dimension
-    expr: str | None = None  # derivation expression, e.g. "nlay * nrow * ncol"
+    ``value`` is always a Python expression string:
+      - bare identifier ``nlay``         → integer field reference
+      - ``len(auxiliary)``               → self-sizing array field reference
+      - anything else, e.g. ``nlay * ncol`` → derived arithmetic expression
+    """
+
+    value: str
     scope: Literal["component", "model", "simulation"] = "component"
-
-    @model_validator(mode="after")
-    def _check_exclusive(self) -> "Dim":
-        if (self.field is None) == (self.expr is None):
-            raise ValueError("Dim must have exactly one of 'field' or 'expr'")
-        return self
-
-    @property
-    def is_derived(self) -> bool:
-        return self.expr is not None
 
 
 def _parents_as_set(parent: "str | list[str] | None") -> set[str]:
@@ -276,43 +283,55 @@ def _can_share_model(
 
 def _resolve_derived_dims(component: "ComponentBase", known_dims: set[str]) -> list[str]:
     """
-    Validate derived dims expressions and return their names in topological order.
-    Raises ValueError on cycles or unresolvable operands.
+    Validate all dim value expressions and return dim names in topological order.
+    Raises ValueError on cycles, unresolvable operands, or invalid field references.
 
     ``known_dims`` is the full set of dim names visible to this component;
     pass ``spec.dims(name)`` or an explicit set in tests.
     """
-    derived = {n: d for n, d in (component.dims or {}).items() if d.is_derived}
-    if not derived:
+    all_dims = component.dims or {}
+    if not all_dims:
         return []
 
-    derived_names = set(derived.keys())
+    local_dim_names = set(all_dims.keys())
     deps: dict[str, set[str]] = {}
 
-    for name, dim_def in derived.items():
-        expr = dim_def.expr
-        assert expr is not None
+    for name, dim_def in all_dims.items():
+        value = dim_def.value
         try:
-            tree = ast.parse(expr, mode="eval")
+            tree = ast.parse(value, mode="eval")
         except SyntaxError as e:
-            raise ValueError(f"Invalid dims {name!r}: {expr!r}: {e}") from e
+            raise ValueError(f"Invalid dims {name!r}: {value!r}: {e}") from e
 
         for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id == "sum"
-            ):
-                _validate_sum_call(node, component, expr)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+                if node.func.id == "len":
+                    _validate_len_call(node, component, value)
+                elif node.func.id == "sum":
+                    _validate_sum_call(node, component, value)
 
-        operands = _names_in_expr(expr)
-        for op in operands:
-            if op not in known_dims and op not in derived_names:
-                raise ValueError(f"dims {name!r} operand {op!r} is not a known dimension")
-        deps[name] = operands & derived_names
+        if _DIM_RE.fullmatch(value):
+            # Bare identifier: must name an Integer field in this component
+            field = component.fields.get(value)
+            if field is None:
+                raise ValueError(f"dims {name!r}: field {value!r} not found in component")
+            if not isinstance(field, Integer):
+                raise ValueError(
+                    f"dims {name!r}: field {value!r} is {type(field).__name__}, "
+                    f"must be Integer (use len({value}) for array fields)"
+                )
+            deps[name] = set()
+        elif _LEN_CALL_RE.fullmatch(value):
+            deps[name] = set()
+        else:
+            operands = _names_in_expr(value)
+            for op in operands:
+                if op not in known_dims and op not in local_dim_names:
+                    raise ValueError(f"dims {name!r} operand {op!r} is not a known dimension")
+            deps[name] = operands & local_dim_names - {name}
 
-    in_degree = dict.fromkeys(derived_names, 0)
-    dependents: dict[str, set[str]] = {n: set() for n in derived_names}
+    in_degree = dict.fromkeys(local_dim_names, 0)
+    dependents: dict[str, set[str]] = {n: set() for n in local_dim_names}
     for name, dep_set in deps.items():
         for dep in dep_set:
             in_degree[name] += 1
@@ -328,7 +347,7 @@ def _resolve_derived_dims(component: "ComponentBase", known_dims: set[str]) -> l
             if in_degree[dependent] == 0:
                 queue.append(dependent)
 
-    if len(order) != len(derived_names):
+    if len(order) != len(local_dim_names):
         cyclic = {n for n, d in in_degree.items() if d > 0}
         raise ValueError(f"Cycle in dims: {cyclic}")
 
@@ -434,6 +453,7 @@ Component = Annotated[
 ]
 
 _DIM_RE = re.compile(r"^[A-Za-z_]\w*$")
+_LEN_CALL_RE = re.compile(r"^len\([A-Za-z_]\w*\)$")
 _LOOKUP_RE = re.compile(r"^(?:([\w-]+)\.)?(\w+)\.(\w+)\((\w+)\)$")
 _BOUND_RE = re.compile(r"^[<>]=?")
 _ARITH_RE = re.compile(r"^([A-Za-z_]\w*)\s*[+-]\s*\d+$")
@@ -864,7 +884,7 @@ class Dfns(BaseModel):
     @model_validator(mode="after")
     def _validate_relations(self) -> "Dfns":
         for name, component in self.components.items():
-            if component.dims and any(d.is_derived for d in component.dims.values()):
+            if component.dims:
                 _resolve_derived_dims(component, self.dims(name))
         for name, component in self.components.items():
             _validate_fk_fields(component, self)

--- a/modflow_devtools/dfns/schema.py
+++ b/modflow_devtools/dfns/schema.py
@@ -155,7 +155,12 @@ List.model_rebuild()
 
 
 def _names_in_expr(expr: str) -> set[str]:
-    """Return Name identifiers from expr, excluding those inside sum() or len() calls."""
+    """Return dim-reference Name identifiers from expr.
+
+    Excluded from the result:
+    - Names in function-call position (never a dim ref, e.g. ``abs``, ``math``)
+    - Arguments of ``sum()`` and ``len()`` calls (domain-specific, handled separately)
+    """
     try:
         tree = ast.parse(expr, mode="eval")
     except SyntaxError as e:
@@ -163,14 +168,15 @@ def _names_in_expr(expr: str) -> set[str]:
 
     excluded_ids: set[int] = set()
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id in ("sum", "len")
-        ):
-            for child in ast.walk(node):
-                if child is not node:
-                    excluded_ids.add(id(child))
+        if isinstance(node, ast.Call):
+            # Function name/path is never a dim ref
+            for child in ast.walk(node.func):
+                excluded_ids.add(id(child))
+            # sum() and len() have domain-specific arguments; exclude those too
+            if isinstance(node.func, ast.Name) and node.func.id in ("sum", "len"):
+                for arg in node.args:
+                    for child in ast.walk(arg):
+                        excluded_ids.add(id(child))
 
     return {
         node.id


### PR DESCRIPTION
Replace separate `field` and `expr` attributes on dimension specifications with a single `value` attribute, which may be

- an integer field name, e.g. `nlay`, or
- `len()` of a size-unspecified 1D array field, e.g. `len(array_field)`, or
- a more complex Python-syntax expression combining other dimensions

Previously only `sum()` and `len()` were supported in expressions, add support for Python builtins as well as `math` module functions