### PR TITLE
fix(dfns): multiple migration fixes

### DIFF
--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-lke.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-lke.json
@@ -134,7 +134,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the lake number associated with the specified PACKAGEDATA data on the line. LAKENO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -188,7 +189,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the lake number associated with the specified PERIOD data on the line. LAKENO must be greater than zero and less than or equal to NLAKES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.lakeno"
               },
               "laksetting": {
                 "type": "union",
@@ -200,9 +202,10 @@
                     "description": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value."
                   },
                   "temperature": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to temperature."
+                    "type": "string",
+                    "longname": "lake temperature",
+                    "description": "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rainfall": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-lke.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-lke.toml
@@ -117,6 +117,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the lake number associated with the specified PACKAGEDATA data on the line. LAKENO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -165,6 +166,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the lake number associated with the specified PERIOD data on the line. LAKENO must be greater than zero and less than or equal to NLAKES."
 tagged = false
+fk = "packagedata.lakeno"
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting]
 type = "union"
@@ -176,9 +178,10 @@ longname = "lake temperature status"
 description = "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value."
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting.arms.temperature]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to temperature."
+type = "string"
+longname = "lake temperature"
+description = "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting.arms.rainfall]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-lke.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-lke.yaml
@@ -132,6 +132,7 @@ blocks:
                 program will also terminate with an error if information for a lake is specified more
                 than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting lake temperature
@@ -184,6 +185,7 @@ blocks:
               description: integer value that defines the lake number associated with the specified PERIOD
                 data on the line. LAKENO must be greater than zero and less than or equal to NLAKES.
               tagged: false
+              fk: packagedata.lakeno
             laksetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -204,9 +206,14 @@ blocks:
                     a lake is constant, then the temperature for the lake will be fixed at the user specified
                     value.
                 temperature:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to temperature.
+                  type: string
+                  longname: lake temperature
+                  description: real or character value that defines the temperature for the lake. The
+                    specified TEMPERATURE is only applied if the lake is a constant temperature lake.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rainfall:
                   type: string
                   longname: rainfall temperature

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-mwe.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-mwe.json
@@ -134,7 +134,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the well number associated with the specified PACKAGEDATA data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS. Well information must be specified for every well or the program will terminate with an error.  The program will also terminate with an error if information for a well is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -188,7 +189,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the well number associated with the specified PERIOD data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.mawno"
               },
               "mwesetting": {
                 "type": "union",
@@ -200,9 +202,10 @@
                     "description": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value."
                   },
                   "temperature": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to temperature."
+                    "type": "string",
+                    "longname": "well temperature",
+                    "description": "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rate": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-mwe.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-mwe.toml
@@ -117,6 +117,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the well number associated with the specified PACKAGEDATA data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS. Well information must be specified for every well or the program will terminate with an error.  The program will also terminate with an error if information for a well is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -165,6 +166,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the well number associated with the specified PERIOD data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS."
 tagged = false
+fk = "packagedata.mawno"
 
 [blocks.period.fields.mweperioddata.item.fields.mwesetting]
 type = "union"
@@ -176,9 +178,10 @@ longname = "well temperature status"
 description = "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value."
 
 [blocks.period.fields.mweperioddata.item.fields.mwesetting.arms.temperature]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to temperature."
+type = "string"
+longname = "well temperature"
+description = "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.mweperioddata.item.fields.mwesetting.arms.rate]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-mwe.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-mwe.yaml
@@ -132,6 +132,7 @@ blocks:
                 error.  The program will also terminate with an error if information for a well is specified
                 more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting well temperature
@@ -184,6 +185,7 @@ blocks:
               description: integer value that defines the well number associated with the specified PERIOD
                 data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS.
               tagged: false
+              fk: packagedata.mawno
             mwesetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -204,9 +206,14 @@ blocks:
                     a well is constant, then the temperature for the well will be fixed at the user specified
                     value.
                 temperature:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to temperature.
+                  type: string
+                  longname: well temperature
+                  description: real or character value that defines the temperature for the well. The
+                    specified TEMPERATURE is only applied if the well is a constant temperature well.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rate:
                   type: string
                   longname: well injection temperature

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-sfe.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-sfe.json
@@ -134,7 +134,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the reach number associated with the specified PACKAGEDATA data on the line. RNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -188,7 +189,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the reach number associated with the specified PERIOD data on the line. RNO must be greater than zero and less than or equal to NREACHES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.rno"
               },
               "reachsetting": {
                 "type": "union",
@@ -200,9 +202,10 @@
                     "description": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value."
                   },
                   "temperature": {
-                    "type": "keyword",
-                    "longname": "temperature keyword",
-                    "description": "keyword to specify that record corresponds to temperature."
+                    "type": "string",
+                    "longname": "reach temperature",
+                    "description": "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rainfall": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-sfe.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-sfe.toml
@@ -117,6 +117,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the reach number associated with the specified PACKAGEDATA data on the line. RNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -165,6 +166,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the reach number associated with the specified PERIOD data on the line. RNO must be greater than zero and less than or equal to NREACHES."
 tagged = false
+fk = "packagedata.rno"
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting]
 type = "union"
@@ -176,9 +178,10 @@ longname = "reach temperature status"
 description = "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value."
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting.arms.temperature]
-type = "keyword"
-longname = "temperature keyword"
-description = "keyword to specify that record corresponds to temperature."
+type = "string"
+longname = "reach temperature"
+description = "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting.arms.rainfall]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-sfe.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-sfe.yaml
@@ -133,6 +133,7 @@ blocks:
                 program will also terminate with an error if information for a reach is specified more
                 than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting reach temperature
@@ -185,6 +186,7 @@ blocks:
               description: integer value that defines the reach number associated with the specified PERIOD
                 data on the line. RNO must be greater than zero and less than or equal to NREACHES.
               tagged: false
+              fk: packagedata.rno
             reachsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -204,9 +206,14 @@ blocks:
                     a reach is constant, then the temperature for the reach will be fixed at the user
                     specified value.
                 temperature:
-                  type: keyword
-                  longname: temperature keyword
-                  description: keyword to specify that record corresponds to temperature.
+                  type: string
+                  longname: reach temperature
+                  description: real or character value that defines the temperature for the reach. The
+                    specified TEMPERATURE is only applied if the reach is a constant temperature reach.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rainfall:
                   type: string
                   longname: rainfall temperature

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-ssm.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-ssm.json
@@ -62,7 +62,7 @@
               "pname": {
                 "type": "string",
                 "longname": "package name",
-                "description": "name of the flow package for which an auxiliary variable contains a source temperature.  If this flow package is represented using an advanced transport package (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified here.",
+                "description": "name of the flow package for which an SPC6 input file contains a source temperature.  If this flow package is represented using an advanced transport package (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified here.",
                 "tagged": false
               },
               "spc6": {

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-ssm.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-ssm.toml
@@ -50,7 +50,7 @@ type = "record"
 [blocks.fileinput.fields.fileinput.item.fields.pname]
 type = "string"
 longname = "package name"
-description = "name of the flow package for which an auxiliary variable contains a source temperature.  If this flow package is represented using an advanced transport package (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified here."
+description = "name of the flow package for which an SPC6 input file contains a source temperature.  If this flow package is represented using an advanced transport package (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified here."
 tagged = false
 
 [blocks.fileinput.fields.fileinput.item.fields.spc6]

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-ssm.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-ssm.yaml
@@ -73,10 +73,9 @@ blocks:
             pname:
               type: string
               longname: package name
-              description: name of the flow package for which an auxiliary variable contains a source
-                temperature.  If this flow package is represented using an advanced transport package
-                (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified
-                here.
+              description: name of the flow package for which an SPC6 input file contains a source temperature.  If
+                this flow package is represented using an advanced transport package (SFE, LKE, MWE, or
+                UZE), then the advanced transport package will override SSM terms specified here.
               tagged: false
             spc6:
               type: keyword

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-uze.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-uze.json
@@ -134,7 +134,8 @@
                 "type": "integer",
                 "longname": "UZF cell number for this entry",
                 "description": "integer value that defines the UZF cell number associated with the specified PACKAGEDATA data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS. Unsaturated zone flow information must be specified for every UZF cell or the program will terminate with an error.  The program also will terminate with an error if information for a UZF cell is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -176,7 +177,8 @@
                 "type": "integer",
                 "longname": "unsaturated zone flow cell number for this entry",
                 "description": "integer value that defines the UZF cell number associated with the specified PERIOD data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.uzfno"
               },
               "uzesetting": {
                 "type": "union",
@@ -188,9 +190,10 @@
                     "description": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value."
                   },
                   "temperature": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to temperature."
+                    "type": "string",
+                    "longname": "unsaturated zone flow cell temperature",
+                    "description": "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "infiltration": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-uze.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-uze.toml
@@ -117,6 +117,7 @@ type = "integer"
 longname = "UZF cell number for this entry"
 description = "integer value that defines the UZF cell number associated with the specified PACKAGEDATA data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS. Unsaturated zone flow information must be specified for every UZF cell or the program will terminate with an error.  The program also will terminate with an error if information for a UZF cell is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -153,6 +154,7 @@ type = "integer"
 longname = "unsaturated zone flow cell number for this entry"
 description = "integer value that defines the UZF cell number associated with the specified PERIOD data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS."
 tagged = false
+fk = "packagedata.uzfno"
 
 [blocks.period.fields.uzeperioddata.item.fields.uzesetting]
 type = "union"
@@ -164,9 +166,10 @@ longname = "unsaturated zone flow cell temperature status"
 description = "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value."
 
 [blocks.period.fields.uzeperioddata.item.fields.uzesetting.arms.temperature]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to temperature."
+type = "string"
+longname = "unsaturated zone flow cell temperature"
+description = "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.uzeperioddata.item.fields.uzesetting.arms.infiltration]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-uze.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwe-uze.yaml
@@ -133,6 +133,7 @@ blocks:
                 program will terminate with an error.  The program also will terminate with an error if
                 information for a UZF cell is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting UZF cell temperature
@@ -174,6 +175,7 @@ blocks:
               description: integer value that defines the UZF cell number associated with the specified
                 PERIOD data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS.
               tagged: false
+              fk: packagedata.uzfno
             uzesetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -191,9 +193,14 @@ blocks:
                     temperature.  If a UZF cell is constant, then the temperature for the UZF cell will
                     be fixed at the user specified value.
                 temperature:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to temperature.
+                  type: string
+                  longname: unsaturated zone flow cell temperature
+                  description: real or character value that defines the temperature for the unsaturated
+                    zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone
+                    flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE
+                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
+                    series by entering the time-series name in place of a numeric value.
+                  time_series: true
                 infiltration:
                   type: string
                   longname: infiltration temperature

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-lak.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-lak.json
@@ -204,7 +204,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -254,8 +255,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "lake number for this entry",
-                "description": "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (lake) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake connection information must be specified for every lake connection to the GWF model (NLAKECONN) or the program will terminate with an error.  The program will also terminate with an error if connection information for a lake connection to the GWF model is specified more than once.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "iconn": {
                 "type": "integer",
@@ -326,8 +328,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "lake number for this entry",
-                "description": "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (lake) number associated with the specified TABLES data on the line. IFNO must be greater than zero and less than or equal to NLAKES. The program will terminate with an error if table information for a lake is specified more than once or the number of specified tables is less than NTABLES.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "tab6": {
                 "type": "keyword",
@@ -365,19 +368,22 @@
                 "type": "integer",
                 "longname": "outlet number for this entry",
                 "description": "integer value that defines the outlet number associated with the specified OUTLETS data on the line. OUTLETNO must be greater than zero and less than or equal to NOUTLETS. Outlet information must be specified for every outlet or the program will terminate with an error. The program will also terminate with an error if information for a outlet is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "lakein": {
                 "type": "integer",
                 "longname": "lake number for upstream lake",
                 "description": "integer value that defines the lake number that outlet is connected to. LAKEIN must be greater than zero and less than or equal to NLAKES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "lakeout": {
                 "type": "integer",
                 "longname": "lake number for downstream lake",
                 "description": "integer value that defines the lake number that outlet discharge from lake outlet OUTLETNO is routed to. LAKEOUT must be greater than or equal to zero and less than or equal to NLAKES. If LAKEOUT is zero, outlet discharge from lake outlet OUTLETNO is discharged to an external boundary.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "couttype": {
                 "type": "string",
@@ -428,93 +434,235 @@
           "item": {
             "type": "record",
             "fields": {
-              "number": {
-                "type": "integer",
-                "longname": "lake or outlet number for this entry",
-                "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
-                "tagged": false
-              },
               "laksetting": {
                 "type": "union",
                 "description": "line of information that is parsed into a keyword and values.  Keyword values that can be used to start the LAKSETTING string include both keywords for lake settings and keywords for outlet settings.  Keywords for lake settings include: STATUS, STAGE, RAINFALL, EVAPORATION, RUNOFF, INFLOW, WITHDRAWAL, and AUXILIARY.  Keywords for outlet settings include RATE, INVERT, WIDTH, SLOPE, and ROUGH.",
                 "arms": {
                   "status": {
-                    "type": "string",
-                    "longname": "lake status",
-                    "description": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE."
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "status": {
+                        "type": "string",
+                        "longname": "lake status",
+                        "description": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE."
+                      }
+                    }
                   },
                   "stage": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to stage."
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "stage": {
+                        "type": "string",
+                        "longname": "lake stage",
+                        "description": "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "rainfall": {
-                    "type": "string",
-                    "longname": "rainfall rate",
-                    "description": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "rainfall": {
+                        "type": "string",
+                        "longname": "rainfall rate",
+                        "description": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "evaporation": {
-                    "type": "string",
-                    "longname": "evaporation rate",
-                    "description": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "evaporation": {
+                        "type": "string",
+                        "longname": "evaporation rate",
+                        "description": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "runoff": {
-                    "type": "string",
-                    "longname": "runoff rate",
-                    "description": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "runoff": {
+                        "type": "string",
+                        "longname": "runoff rate",
+                        "description": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "inflow": {
-                    "type": "string",
-                    "longname": "inflow rate",
-                    "description": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "inflow": {
+                        "type": "string",
+                        "longname": "inflow rate",
+                        "description": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "withdrawal": {
-                    "type": "string",
-                    "longname": "maximum withdrawal rate",
-                    "description": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "withdrawal": {
+                        "type": "string",
+                        "longname": "maximum withdrawal rate",
+                        "description": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "rate": {
-                    "type": "string",
-                    "longname": "extraction rate",
-                    "description": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "rate": {
+                        "type": "string",
+                        "longname": "extraction rate",
+                        "description": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "invert": {
-                    "type": "double",
-                    "longname": "invert elevation",
-                    "description": "real value that defines the invert elevation for the lake outlet. Any value can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "tagged": false,
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "invert": {
+                        "type": "string",
+                        "longname": "invert elevation",
+                        "description": "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "width": {
-                    "type": "double",
-                    "longname": "outlet width",
-                    "description": "real value that defines the width of the lake outlet. Any value can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "tagged": false,
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "width": {
+                        "type": "string",
+                        "longname": "outlet width",
+                        "description": "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "slope": {
-                    "type": "double",
-                    "longname": "bed slope",
-                    "description": "real value that defines the bed slope for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "tagged": false,
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "slope": {
+                        "type": "string",
+                        "longname": "bed slope",
+                        "description": "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "rough": {
-                    "type": "double",
-                    "longname": "roughness coefficient",
-                    "description": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "tagged": false,
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "rough": {
+                        "type": "string",
+                        "longname": "roughness coefficient",
+                        "description": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "auxiliaryrecord": {
                     "type": "record",
                     "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
                       "auxiliary": {
                         "type": "keyword",
                         "description": "keyword for specifying auxiliary variable."

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-lak.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-lak.toml
@@ -184,6 +184,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -227,8 +228,9 @@ type = "record"
 [blocks.connectiondata.fields.connectiondata.item.fields.ifno]
 type = "integer"
 longname = "lake number for this entry"
-description = "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
+description = "integer value that defines the feature (lake) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake connection information must be specified for every lake connection to the GWF model (NLAKECONN) or the program will terminate with an error.  The program will also terminate with an error if connection information for a lake connection to the GWF model is specified more than once."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.connectiondata.fields.connectiondata.item.fields.iconn]
 type = "integer"
@@ -293,8 +295,9 @@ type = "record"
 [blocks.tables.fields.tables.item.fields.ifno]
 type = "integer"
 longname = "lake number for this entry"
-description = "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
+description = "integer value that defines the feature (lake) number associated with the specified TABLES data on the line. IFNO must be greater than zero and less than or equal to NLAKES. The program will terminate with an error if table information for a lake is specified more than once or the number of specified tables is less than NTABLES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.tables.fields.tables.item.fields.tab6]
 type = "keyword"
@@ -327,18 +330,21 @@ type = "integer"
 longname = "outlet number for this entry"
 description = "integer value that defines the outlet number associated with the specified OUTLETS data on the line. OUTLETNO must be greater than zero and less than or equal to NOUTLETS. Outlet information must be specified for every outlet or the program will terminate with an error. The program will also terminate with an error if information for a outlet is specified more than once."
 tagged = false
+pk = true
 
 [blocks.outlets.fields.outlets.item.fields.lakein]
 type = "integer"
 longname = "lake number for upstream lake"
 description = "integer value that defines the lake number that outlet is connected to. LAKEIN must be greater than zero and less than or equal to NLAKES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.outlets.fields.outlets.item.fields.lakeout]
 type = "integer"
 longname = "lake number for downstream lake"
 description = "integer value that defines the lake number that outlet discharge from lake outlet OUTLETNO is routed to. LAKEOUT must be greater than or equal to zero and less than or equal to NLAKES. If LAKEOUT is zero, outlet discharge from lake outlet OUTLETNO is discharged to an external boundary."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.outlets.fields.outlets.item.fields.couttype]
 type = "string"
@@ -380,92 +386,210 @@ type = "list"
 [blocks.period.fields.perioddata.item]
 type = "record"
 
-[blocks.period.fields.perioddata.item.fields.number]
-type = "integer"
-longname = "lake or outlet number for this entry"
-description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
-tagged = false
-
 [blocks.period.fields.perioddata.item.fields.laksetting]
 type = "union"
 description = "line of information that is parsed into a keyword and values.  Keyword values that can be used to start the LAKSETTING string include both keywords for lake settings and keywords for outlet settings.  Keywords for lake settings include: STATUS, STAGE, RAINFALL, EVAPORATION, RUNOFF, INFLOW, WITHDRAWAL, and AUXILIARY.  Keywords for outlet settings include RATE, INVERT, WIDTH, SLOPE, and ROUGH."
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.status]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.status.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.status.fields.status]
 type = "string"
 longname = "lake status"
 description = "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE."
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.stage]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to stage."
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.stage.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.stage.fields.stage]
+type = "string"
+longname = "lake stage"
+description = "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.rainfall]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rainfall.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rainfall.fields.rainfall]
 type = "string"
 longname = "rainfall rate"
 description = "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.evaporation]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.evaporation.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.evaporation.fields.evaporation]
 type = "string"
 longname = "evaporation rate"
 description = "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.runoff]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.runoff.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.runoff.fields.runoff]
 type = "string"
 longname = "runoff rate"
 description = "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.inflow]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.inflow.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.inflow.fields.inflow]
 type = "string"
 longname = "inflow rate"
 description = "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.withdrawal]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.withdrawal.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.withdrawal.fields.withdrawal]
 type = "string"
 longname = "maximum withdrawal rate"
 description = "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.rate]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rate.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rate.fields.rate]
 type = "string"
 longname = "extraction rate"
 description = "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.invert]
-type = "double"
-longname = "invert elevation"
-description = "real value that defines the invert elevation for the lake outlet. Any value can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.invert.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
 tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.invert.fields.invert]
+type = "string"
+longname = "invert elevation"
+description = "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.width]
-type = "double"
-longname = "outlet width"
-description = "real value that defines the width of the lake outlet. Any value can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.width.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
 tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.width.fields.width]
+type = "string"
+longname = "outlet width"
+description = "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.slope]
-type = "double"
-longname = "bed slope"
-description = "real value that defines the bed slope for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.slope.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
 tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.slope.fields.slope]
+type = "string"
+longname = "bed slope"
+description = "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.rough]
-type = "double"
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rough.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rough.fields.rough]
+type = "string"
 longname = "roughness coefficient"
 description = "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-tagged = false
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.auxiliaryrecord]
 type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.auxiliaryrecord.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.auxiliaryrecord.fields.auxiliary]
 type = "keyword"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-lak.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-lak.yaml
@@ -203,6 +203,7 @@ blocks:
                 with an error.  The program will also terminate with an error if information for a lake
                 is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting lake stage
@@ -250,11 +251,13 @@ blocks:
               type: integer
               longname: lake number for this entry
               description: integer value that defines the feature (lake) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NLAKES. Lake information must be specified for every lake or the program will terminate
-                with an error.  The program will also terminate with an error if information for a lake
-                is specified more than once.
+                CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal
+                to NLAKES. Lake connection information must be specified for every lake connection to
+                the GWF model (NLAKECONN) or the program will terminate with an error.  The program will
+                also terminate with an error if connection information for a lake connection to the GWF
+                model is specified more than once.
               tagged: false
+              fk: packagedata.ifno
             iconn:
               type: integer
               longname: connection number for this entry
@@ -347,11 +350,11 @@ blocks:
               type: integer
               longname: lake number for this entry
               description: integer value that defines the feature (lake) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NLAKES. Lake information must be specified for every lake or the program will terminate
-                with an error.  The program will also terminate with an error if information for a lake
-                is specified more than once.
+                TABLES data on the line. IFNO must be greater than zero and less than or equal to NLAKES.
+                The program will terminate with an error if table information for a lake is specified
+                more than once or the number of specified tables is less than NTABLES.
               tagged: false
+              fk: packagedata.ifno
             tab6:
               type: keyword
               longname: head keyword
@@ -389,12 +392,14 @@ blocks:
                 with an error. The program will also terminate with an error if information for a outlet
                 is specified more than once.
               tagged: false
+              pk: true
             lakein:
               type: integer
               longname: lake number for upstream lake
               description: integer value that defines the lake number that outlet is connected to. LAKEIN
                 must be greater than zero and less than or equal to NLAKES.
               tagged: false
+              fk: packagedata.ifno
             lakeout:
               type: integer
               longname: lake number for downstream lake
@@ -403,6 +408,7 @@ blocks:
                 or equal to NLAKES. If LAKEOUT is zero, outlet discharge from lake outlet OUTLETNO is
                 discharged to an external boundary.
               tagged: false
+              fk: packagedata.ifno
             couttype:
               type: string
               longname: outlet type
@@ -457,13 +463,6 @@ blocks:
         item:
           type: record
           fields:
-            number:
-              type: integer
-              longname: lake or outlet number for this entry
-              description: integer value that defines the lake or outlet number associated with the specified
-                PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES
-                for a lake number and less than or equal to NOUTLETS for an outlet number.
-              tagged: false
             laksetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -473,106 +472,268 @@ blocks:
                 settings include RATE, INVERT, WIDTH, SLOPE, and ROUGH.'
               arms:
                 status:
-                  type: string
-                  longname: lake status
-                  description: keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE,
-                    or CONSTANT. By default, STATUS is ACTIVE.
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    status:
+                      type: string
+                      longname: lake status
+                      description: keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE,
+                        or CONSTANT. By default, STATUS is ACTIVE.
                 stage:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to stage.
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    stage:
+                      type: string
+                      longname: lake stage
+                      description: real or character value that defines the stage for the lake. The specified
+                        STAGE is only applied if the lake is a constant stage lake. If the Options block
+                        includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
+                        can be obtained from a time series by entering the time-series name in place of
+                        a numeric value.
+                      time_series: true
                 rainfall:
-                  type: string
-                  longname: rainfall rate
-                  description: real or character value that defines the rainfall rate $(LT^{-1})$ for
-                    the lake. Value must be greater than or equal to zero. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    rainfall:
+                      type: string
+                      longname: rainfall rate
+                      description: real or character value that defines the rainfall rate $(LT^{-1})$
+                        for the lake. Value must be greater than or equal to zero. If the Options block
+                        includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
+                        can be obtained from a time series by entering the time-series name in place of
+                        a numeric value.
+                      time_series: true
                 evaporation:
-                  type: string
-                  longname: evaporation rate
-                  description: real or character value that defines the maximum evaporation rate $(LT^{-1})$
-                    for the lake. Value must be greater than or equal to zero. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    evaporation:
+                      type: string
+                      longname: evaporation rate
+                      description: real or character value that defines the maximum evaporation rate $(LT^{-1})$
+                        for the lake. Value must be greater than or equal to zero. If the Options block
+                        includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
+                        can be obtained from a time series by entering the time-series name in place of
+                        a numeric value.
+                      time_series: true
                 runoff:
-                  type: string
-                  longname: runoff rate
-                  description: real or character value that defines the runoff rate $(L^3 T^{-1})$ for
-                    the lake. Value must be greater than or equal to zero. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    runoff:
+                      type: string
+                      longname: runoff rate
+                      description: real or character value that defines the runoff rate $(L^3 T^{-1})$
+                        for the lake. Value must be greater than or equal to zero. If the Options block
+                        includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
+                        can be obtained from a time series by entering the time-series name in place of
+                        a numeric value.
+                      time_series: true
                 inflow:
-                  type: string
-                  longname: inflow rate
-                  description: real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$
-                    for the lake. Value must be greater than or equal to zero. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value. By
-                    default, inflow rates are zero for each lake.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    inflow:
+                      type: string
+                      longname: inflow rate
+                      description: real or character value that defines the volumetric inflow rate $(L^3
+                        T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options
+                        block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section),
+                        values can be obtained from a time series by entering the time-series name in
+                        place of a numeric value. By default, inflow rates are zero for each lake.
+                      time_series: true
                 withdrawal:
-                  type: string
-                  longname: maximum withdrawal rate
-                  description: real or character value that defines the maximum withdrawal rate $(L^3
-                    T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options
-                    block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
-                    can be obtained from a time series by entering the time-series name in place of a
-                    numeric value.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    withdrawal:
+                      type: string
+                      longname: maximum withdrawal rate
+                      description: real or character value that defines the maximum withdrawal rate $(L^3
+                        T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options
+                        block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section),
+                        values can be obtained from a time series by entering the time-series name in
+                        place of a numeric value.
+                      time_series: true
                 rate:
-                  type: string
-                  longname: extraction rate
-                  description: real or character value that defines the extraction rate for the lake outflow.
-                    A positive value indicates inflow and a negative value indicates outflow from the
-                    lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE).
-                    A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the
-                    Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section),
-                    values can be obtained from a time series by entering the time-series name in place
-                    of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    rate:
+                      type: string
+                      longname: extraction rate
+                      description: real or character value that defines the extraction rate for the lake
+                        outflow. A positive value indicates inflow and a negative value indicates outflow
+                        from the lake. RATE only applies to outlets associated with active lakes (STATUS
+                        is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED.
+                        If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                        section), values can be obtained from a time series by entering the time-series
+                        name in place of a numeric value. By default, the RATE for each SPECIFIED lake
+                        outlet is zero.
+                      time_series: true
                 invert:
-                  type: double
-                  longname: invert elevation
-                  description: real value that defines the invert elevation for the lake outlet. Any value
-                    can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE
-                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
-                    series by entering the time-series name in place of a numeric value.
-                  tagged: false
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    invert:
+                      type: string
+                      longname: invert elevation
+                      description: real or character value that defines the invert elevation for the lake
+                        outlet. A specified INVERT value is only used for active lakes if COUTTYPE for
+                        lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE
+                        entry (see the 'Time-Variable Input' section), values can be obtained from a time
+                        series by entering the time-series name in place of a numeric value.
+                      time_series: true
                 width:
-                  type: double
-                  longname: outlet width
-                  description: real value that defines the width of the lake outlet. Any value can be
-                    specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE
-                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
-                    series by entering the time-series name in place of a numeric value.
-                  tagged: false
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    width:
+                      type: string
+                      longname: outlet width
+                      description: real or character value that defines the width of the lake outlet.
+                        A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet
+                        OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry
+                        (see the 'Time-Variable Input' section), values can be obtained from a time series
+                        by entering the time-series name in place of a numeric value.
+                      time_series: true
                 slope:
-                  type: double
-                  longname: bed slope
-                  description: real value that defines the bed slope for the lake outlet. Any value can
-                    be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE
-                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
-                    series by entering the time-series name in place of a numeric value.
-                  tagged: false
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    slope:
+                      type: string
+                      longname: bed slope
+                      description: real or character value that defines the bed slope for the lake outlet.
+                        A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet
+                        OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see
+                        the 'Time-Variable Input' section), values can be obtained from a time series
+                        by entering the time-series name in place of a numeric value.
+                      time_series: true
                 rough:
-                  type: double
-                  longname: roughness coefficient
-                  description: real value that defines the roughness coefficient for the lake outlet.
-                    Any value can be specified if COUTTYPE is not MANNING. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value.
-                  tagged: false
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    rough:
+                      type: string
+                      longname: roughness coefficient
+                      description: real value that defines the roughness coefficient for the lake outlet.
+                        Any value can be specified if COUTTYPE is not MANNING. If the Options block includes
+                        a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be
+                        obtained from a time series by entering the time-series name in place of a numeric
+                        value.
+                      time_series: true
                 auxiliaryrecord:
                   type: record
                   fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
                     auxiliary:
                       type: keyword
                       description: keyword for specifying auxiliary variable.

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-maw.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-maw.json
@@ -182,7 +182,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well or the program will terminate with an error.  The program will also terminate with an error if information for a multi-aquifer well is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "radius": {
                 "type": "double",
@@ -250,8 +251,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "well number for this entry",
-                "description": "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well or the program will terminate with an error.  The program will also terminate with an error if information for a multi-aquifer well is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (well) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well connection information must be specified for every multi-aquifer well connection to the GWF model (NGWFNODES) or the program will terminate with an error.  The program will also terminate with an error if connection information for a multi-aquifer well connection to the GWF model is specified more than once.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "icon": {
                 "type": "integer",
@@ -308,7 +310,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the well number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "mawsetting": {
                 "type": "union",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-maw.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-maw.toml
@@ -162,6 +162,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well or the program will terminate with an error.  The program will also terminate with an error if information for a multi-aquifer well is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.radius]
 type = "double"
@@ -220,8 +221,9 @@ type = "record"
 [blocks.connectiondata.fields.connectiondata.item.fields.ifno]
 type = "integer"
 longname = "well number for this entry"
-description = "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well or the program will terminate with an error.  The program will also terminate with an error if information for a multi-aquifer well is specified more than once."
+description = "integer value that defines the feature (well) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well connection information must be specified for every multi-aquifer well connection to the GWF model (NGWFNODES) or the program will terminate with an error.  The program will also terminate with an error if connection information for a multi-aquifer well connection to the GWF model is specified more than once."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.connectiondata.fields.connectiondata.item.fields.icon]
 type = "integer"
@@ -273,6 +275,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the well number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.perioddata.item.fields.mawsetting]
 type = "union"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-maw.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-maw.yaml
@@ -188,6 +188,7 @@ blocks:
                 or the program will terminate with an error.  The program will also terminate with an
                 error if information for a multi-aquifer well is specified more than once.
               tagged: false
+              pk: true
             radius:
               type: double
               longname: well radius
@@ -274,11 +275,13 @@ blocks:
               type: integer
               longname: well number for this entry
               description: integer value that defines the feature (well) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well
-                or the program will terminate with an error.  The program will also terminate with an
-                error if information for a multi-aquifer well is specified more than once.
+                CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal
+                to NMAWWELLS. Multi-aquifer well connection information must be specified for every multi-aquifer
+                well connection to the GWF model (NGWFNODES) or the program will terminate with an error.  The
+                program will also terminate with an error if connection information for a multi-aquifer
+                well connection to the GWF model is specified more than once.
               tagged: false
+              fk: packagedata.ifno
             icon:
               type: integer
               longname: connection number
@@ -355,6 +358,7 @@ blocks:
               description: integer value that defines the well number associated with the specified PERIOD
                 data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS.
               tagged: false
+              fk: packagedata.ifno
             mawsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-sfr.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-sfr.json
@@ -311,8 +311,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "reach number for this entry",
-                "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (reach) number associated with the specified cross-section table file on the line. IFNO must be greater than zero and less than or equal to NREACHES. The program will also terminate with an error if table information for a reach is specified more than once.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "tab6": {
                 "type": "keyword",
@@ -346,7 +347,7 @@
               "ifno": {
                 "type": "integer",
                 "longname": "reach number for this entry",
-                "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
+                "description": "integer value that defines the feature (reach) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach connection information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if connection information for a reach is specified more than once.",
                 "tagged": false,
                 "fk": "packagedata.ifno"
               },
@@ -375,8 +376,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "reach number for this entry",
-                "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (reach) number associated with the specified DIVERSIONS data on the line. IFNO must be greater than zero and less than or equal to NREACHES.  Reach diversion information must be specified for every reach with a NDV value greater than 0 or the program will terminate with an error.  The program will also terminate with an error if diversion information for a given reach diversion is specified more than once.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "idv": {
                 "type": "integer",
@@ -411,8 +413,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "reach number for this entry",
-                "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (reach) number associated with the specified initial stage. Initial stage data must be specified for every reach or the program will terminate with an error. The program will also terminate with a error if IFNO is less than one or greater than NREACHES.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "initialstage": {
                 "type": "double",
@@ -436,7 +439,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the feature (reach) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "sfrsetting": {
                 "type": "union",
@@ -460,9 +464,10 @@
                     "time_series": true
                   },
                   "stage": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to stage."
+                    "type": "string",
+                    "longname": "reach stage",
+                    "description": "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "inflow": {
                     "type": "string",
@@ -498,8 +503,8 @@
                       },
                       "idv": {
                         "type": "integer",
-                        "longname": "downstream diversion number",
-                        "description": "integer value that defines the downstream diversion number for the diversion for reach IFNO. IDV must be greater than zero and less than or equal to NDV for reach IFNO.",
+                        "longname": "diversion number",
+                        "description": "an integer value specifying which diversion of reach IFNO that DIVFLOW is being specified for.  Must be less or equal to ndv for the current reach (IFNO).",
                         "tagged": false
                       },
                       "divflow": {

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-sfr.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-sfr.toml
@@ -281,8 +281,9 @@ type = "record"
 [blocks.crosssections.fields.crosssections.item.fields.ifno]
 type = "integer"
 longname = "reach number for this entry"
-description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
+description = "integer value that defines the feature (reach) number associated with the specified cross-section table file on the line. IFNO must be greater than zero and less than or equal to NREACHES. The program will also terminate with an error if table information for a reach is specified more than once."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.crosssections.fields.crosssections.item.fields.tab6]
 type = "keyword"
@@ -310,7 +311,7 @@ type = "record"
 [blocks.connectiondata.fields.connectiondata.item.fields.ifno]
 type = "integer"
 longname = "reach number for this entry"
-description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
+description = "integer value that defines the feature (reach) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach connection information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if connection information for a reach is specified more than once."
 tagged = false
 fk = "packagedata.ifno"
 
@@ -333,8 +334,9 @@ type = "record"
 [blocks.diversions.fields.diversions.item.fields.ifno]
 type = "integer"
 longname = "reach number for this entry"
-description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
+description = "integer value that defines the feature (reach) number associated with the specified DIVERSIONS data on the line. IFNO must be greater than zero and less than or equal to NREACHES.  Reach diversion information must be specified for every reach with a NDV value greater than 0 or the program will terminate with an error.  The program will also terminate with an error if diversion information for a given reach diversion is specified more than once."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.diversions.fields.diversions.item.fields.idv]
 type = "integer"
@@ -363,8 +365,9 @@ type = "record"
 [blocks.initialstages.fields.initialstages.item.fields.ifno]
 type = "integer"
 longname = "reach number for this entry"
-description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
+description = "integer value that defines the feature (reach) number associated with the specified initial stage. Initial stage data must be specified for every reach or the program will terminate with an error. The program will also terminate with a error if IFNO is less than one or greater than NREACHES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.initialstages.fields.initialstages.item.fields.initialstage]
 type = "double"
@@ -383,6 +386,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the feature (reach) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting]
 type = "union"
@@ -406,9 +410,10 @@ description = "real or character value that defines the Manning's roughness coef
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting.arms.stage]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to stage."
+type = "string"
+longname = "reach stage"
+description = "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting.arms.inflow]
 type = "string"
@@ -444,8 +449,8 @@ description = "keyword to indicate diversion record."
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting.arms.diversionrecord.fields.idv]
 type = "integer"
-longname = "downstream diversion number"
-description = "integer value that defines the downstream diversion number for the diversion for reach IFNO. IDV must be greater than zero and less than or equal to NDV for reach IFNO."
+longname = "diversion number"
+description = "an integer value specifying which diversion of reach IFNO that DIVFLOW is being specified for.  Must be less or equal to ndv for the current reach (IFNO)."
 tagged = false
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting.arms.diversionrecord.fields.divflow]

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-sfr.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-sfr.yaml
@@ -329,11 +329,11 @@ blocks:
               type: integer
               longname: reach number for this entry
               description: integer value that defines the feature (reach) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NREACHES. Reach information must be specified for every reach or the program will terminate
-                with an error.  The program will also terminate with an error if information for a reach
-                is specified more than once.
+                cross-section table file on the line. IFNO must be greater than zero and less than or
+                equal to NREACHES. The program will also terminate with an error if table information
+                for a reach is specified more than once.
               tagged: false
+              fk: packagedata.ifno
             tab6:
               type: keyword
               longname: head keyword
@@ -363,10 +363,10 @@ blocks:
               type: integer
               longname: reach number for this entry
               description: integer value that defines the feature (reach) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NREACHES. Reach information must be specified for every reach or the program will terminate
-                with an error.  The program will also terminate with an error if information for a reach
-                is specified more than once.
+                CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal
+                to NREACHES. Reach connection information must be specified for every reach or the program
+                will terminate with an error.  The program will also terminate with an error if connection
+                information for a reach is specified more than once.
               tagged: false
               fk: packagedata.ifno
             ic:
@@ -394,11 +394,13 @@ blocks:
               type: integer
               longname: reach number for this entry
               description: integer value that defines the feature (reach) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NREACHES. Reach information must be specified for every reach or the program will terminate
-                with an error.  The program will also terminate with an error if information for a reach
-                is specified more than once.
+                DIVERSIONS data on the line. IFNO must be greater than zero and less than or equal to
+                NREACHES.  Reach diversion information must be specified for every reach with a NDV value
+                greater than 0 or the program will terminate with an error.  The program will also terminate
+                with an error if diversion information for a given reach diversion is specified more than
+                once.
               tagged: false
+              fk: packagedata.ifno
             idv:
               type: integer
               longname: downstream diversion number
@@ -447,11 +449,11 @@ blocks:
               type: integer
               longname: reach number for this entry
               description: integer value that defines the feature (reach) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NREACHES. Reach information must be specified for every reach or the program will terminate
-                with an error.  The program will also terminate with an error if information for a reach
-                is specified more than once.
+                initial stage. Initial stage data must be specified for every reach or the program will
+                terminate with an error. The program will also terminate with a error if IFNO is less
+                than one or greater than NREACHES.
               tagged: false
+              fk: packagedata.ifno
             initialstage:
               type: double
               longname: initial reach stage
@@ -474,6 +476,7 @@ blocks:
               description: integer value that defines the feature (reach) number associated with the specified
                 PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES.
               tagged: false
+              fk: packagedata.ifno
             sfrsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -513,9 +516,15 @@ blocks:
                     from a time series by entering the time-series name in place of a numeric value.
                   time_series: true
                 stage:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to stage.
+                  type: string
+                  longname: reach stage
+                  description: real or character value that defines the stage for the reach. The specified
+                    STAGE is only applied if the reach uses the simple routing option. If STAGE is not
+                    specified for reaches that use the simple routing option, the specified stage is set
+                    to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see
+                    the 'Time-Variable Input' section), values can be obtained from a time series by entering
+                    the time-series name in place of a numeric value.
+                  time_series: true
                 inflow:
                   type: string
                   longname: inflow rate
@@ -568,10 +577,9 @@ blocks:
                       description: keyword to indicate diversion record.
                     idv:
                       type: integer
-                      longname: downstream diversion number
-                      description: integer value that defines the downstream diversion number for the
-                        diversion for reach IFNO. IDV must be greater than zero and less than or equal
-                        to NDV for reach IFNO.
+                      longname: diversion number
+                      description: an integer value specifying which diversion of reach IFNO that DIVFLOW
+                        is being specified for.  Must be less or equal to ndv for the current reach (IFNO).
                       tagged: false
                     divflow:
                       type: double

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-uzf.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-uzf.json
@@ -207,7 +207,8 @@
                 "type": "integer",
                 "longname": "uzf id number for this entry",
                 "description": "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "cellid": {
                 "type": "array",
@@ -290,9 +291,10 @@
             "fields": {
               "ifno": {
                 "type": "integer",
-                "longname": "uzf id number for this entry",
-                "description": "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once.",
-                "tagged": false
+                "longname": "UZF id number",
+                "description": "integer value that defines the feature (UZF object) number associated with the specified PERIOD data on the line.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "finf": {
                 "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-uzf.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-uzf.toml
@@ -187,6 +187,7 @@ type = "integer"
 longname = "uzf id number for this entry"
 description = "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.cellid]
 type = "array"
@@ -260,9 +261,10 @@ type = "record"
 
 [blocks.period.fields.perioddata.item.fields.ifno]
 type = "integer"
-longname = "uzf id number for this entry"
-description = "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once."
+longname = "UZF id number"
+description = "integer value that defines the feature (UZF object) number associated with the specified PERIOD data on the line."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.perioddata.item.fields.finf]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-uzf.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwf-uzf.yaml
@@ -204,6 +204,7 @@ blocks:
                 will terminate with an error.  The program will also terminate with an error if information
                 for a UZF cell is specified more than once.
               tagged: false
+              pk: true
             cellid:
               type: array
               longname: cell identifier
@@ -288,13 +289,11 @@ blocks:
           fields:
             ifno:
               type: integer
-              longname: uzf id number for this entry
+              longname: UZF id number
               description: integer value that defines the feature (UZF object) number associated with
-                the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than
-                or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program
-                will terminate with an error.  The program will also terminate with an error if information
-                for a UZF cell is specified more than once.
+                the specified PERIOD data on the line.
               tagged: false
+              fk: packagedata.ifno
             finf:
               type: string
               longname: infiltration rate

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-lkt.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-lkt.json
@@ -134,7 +134,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -176,7 +177,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the feature (lake) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NLAKES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "laksetting": {
                 "type": "union",
@@ -188,9 +190,10 @@
                     "description": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value."
                   },
                   "concentration": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to concentration."
+                    "type": "string",
+                    "longname": "lake concentration",
+                    "description": "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rainfall": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-lkt.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-lkt.toml
@@ -117,6 +117,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -153,6 +154,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the feature (lake) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NLAKES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting]
 type = "union"
@@ -164,9 +166,10 @@ longname = "lake concentration status"
 description = "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value."
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting.arms.concentration]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to concentration."
+type = "string"
+longname = "lake concentration"
+description = "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting.arms.rainfall]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-lkt.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-lkt.yaml
@@ -132,6 +132,7 @@ blocks:
                 with an error.  The program will also terminate with an error if information for a lake
                 is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting lake concentration
@@ -172,6 +173,7 @@ blocks:
               description: integer value that defines the feature (lake) number associated with the specified
                 PERIOD data on the line. IFNO must be greater than zero and less than or equal to NLAKES.
               tagged: false
+              fk: packagedata.ifno
             laksetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -192,9 +194,14 @@ blocks:
                     concentration.  If a lake is constant, then the concentration for the lake will be
                     fixed at the user specified value.
                 concentration:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to concentration.
+                  type: string
+                  longname: lake concentration
+                  description: real or character value that defines the concentration for the lake. The
+                    specified CONCENTRATION is only applied if the lake is a constant concentration lake.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rainfall:
                   type: string
                   longname: rainfall concentration

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-mwt.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-mwt.json
@@ -134,7 +134,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Well information must be specified for every well or the program will terminate with an error.  The program will also terminate with an error if information for a well is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -176,7 +177,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the feature (well) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "mwtsetting": {
                 "type": "union",
@@ -188,9 +190,10 @@
                     "description": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value."
                   },
                   "concentration": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to concentration."
+                    "type": "string",
+                    "longname": "well concentration",
+                    "description": "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rate": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-mwt.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-mwt.toml
@@ -117,6 +117,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Well information must be specified for every well or the program will terminate with an error.  The program will also terminate with an error if information for a well is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -153,6 +154,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the feature (well) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.mwtperioddata.item.fields.mwtsetting]
 type = "union"
@@ -164,9 +166,10 @@ longname = "well concentration status"
 description = "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value."
 
 [blocks.period.fields.mwtperioddata.item.fields.mwtsetting.arms.concentration]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to concentration."
+type = "string"
+longname = "well concentration"
+description = "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.mwtperioddata.item.fields.mwtsetting.arms.rate]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-mwt.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-mwt.yaml
@@ -132,6 +132,7 @@ blocks:
                 with an error.  The program will also terminate with an error if information for a well
                 is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting well concentration
@@ -172,6 +173,7 @@ blocks:
               description: integer value that defines the feature (well) number associated with the specified
                 PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS.
               tagged: false
+              fk: packagedata.ifno
             mwtsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -192,9 +194,14 @@ blocks:
                     concentration.  If a well is constant, then the concentration for the well will be
                     fixed at the user specified value.
                 concentration:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to concentration.
+                  type: string
+                  longname: well concentration
+                  description: real or character value that defines the concentration for the well. The
+                    specified CONCENTRATION is only applied if the well is a constant concentration well.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rate:
                   type: string
                   longname: well injection concentration

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-sft.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-sft.json
@@ -134,7 +134,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -176,7 +177,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the feature (reach) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "reachsetting": {
                 "type": "union",
@@ -188,9 +190,10 @@
                     "description": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value."
                   },
                   "concentration": {
-                    "type": "keyword",
-                    "longname": "concentration keyword",
-                    "description": "keyword to specify that record corresponds to concentration."
+                    "type": "string",
+                    "longname": "reach concentration",
+                    "description": "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rainfall": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-sft.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-sft.toml
@@ -117,6 +117,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -153,6 +154,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the feature (reach) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting]
 type = "union"
@@ -164,9 +166,10 @@ longname = "reach concentration status"
 description = "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value."
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting.arms.concentration]
-type = "keyword"
-longname = "concentration keyword"
-description = "keyword to specify that record corresponds to concentration."
+type = "string"
+longname = "reach concentration"
+description = "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting.arms.rainfall]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-sft.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-sft.yaml
@@ -132,6 +132,7 @@ blocks:
                 with an error.  The program will also terminate with an error if information for a reach
                 is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting reach concentration
@@ -172,6 +173,7 @@ blocks:
               description: integer value that defines the feature (reach) number associated with the specified
                 PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES.
               tagged: false
+              fk: packagedata.ifno
             reachsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -191,9 +193,14 @@ blocks:
                     concentration.  If a reach is constant, then the concentration for the reach will
                     be fixed at the user specified value.
                 concentration:
-                  type: keyword
-                  longname: concentration keyword
-                  description: keyword to specify that record corresponds to concentration.
+                  type: string
+                  longname: reach concentration
+                  description: real or character value that defines the concentration for the reach. The
+                    specified CONCENTRATION is only applied if the reach is a constant concentration reach.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rainfall:
                   type: string
                   longname: rainfall concentration

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-ssm.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-ssm.json
@@ -62,7 +62,7 @@
               "pname": {
                 "type": "string",
                 "longname": "package name",
-                "description": "name of the flow package for which an auxiliary variable contains a source concentration.  If this flow package is represented using an advanced transport package (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified here.",
+                "description": "name of the flow package for which an SPC6 input file contains a source concentration.  If this flow package is represented using an advanced transport package (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified here.",
                 "tagged": false
               },
               "spc6": {

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-ssm.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-ssm.toml
@@ -50,7 +50,7 @@ type = "record"
 [blocks.fileinput.fields.fileinput.item.fields.pname]
 type = "string"
 longname = "package name"
-description = "name of the flow package for which an auxiliary variable contains a source concentration.  If this flow package is represented using an advanced transport package (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified here."
+description = "name of the flow package for which an SPC6 input file contains a source concentration.  If this flow package is represented using an advanced transport package (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified here."
 tagged = false
 
 [blocks.fileinput.fields.fileinput.item.fields.spc6]

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-ssm.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-ssm.yaml
@@ -73,10 +73,9 @@ blocks:
             pname:
               type: string
               longname: package name
-              description: name of the flow package for which an auxiliary variable contains a source
-                concentration.  If this flow package is represented using an advanced transport package
-                (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified
-                here.
+              description: name of the flow package for which an SPC6 input file contains a source concentration.  If
+                this flow package is represented using an advanced transport package (SFT, LKT, MWT, or
+                UZT), then the advanced transport package will override SSM terms specified here.
               tagged: false
             spc6:
               type: keyword

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-uzt.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-uzt.json
@@ -134,7 +134,8 @@
                 "type": "integer",
                 "longname": "UZF cell number for this entry",
                 "description": "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS. Unsaturated zone flow information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -176,7 +177,8 @@
                 "type": "integer",
                 "longname": "unsaturated zone flow cell number for this entry",
                 "description": "integer value that defines the feature (UZF object) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "uztsetting": {
                 "type": "union",
@@ -188,9 +190,10 @@
                     "description": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value."
                   },
                   "concentration": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to concentration."
+                    "type": "string",
+                    "longname": "unsaturated zone flow cell concentration",
+                    "description": "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "infiltration": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-uzt.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-uzt.toml
@@ -117,6 +117,7 @@ type = "integer"
 longname = "UZF cell number for this entry"
 description = "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS. Unsaturated zone flow information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -153,6 +154,7 @@ type = "integer"
 longname = "unsaturated zone flow cell number for this entry"
 description = "integer value that defines the feature (UZF object) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.uztperioddata.item.fields.uztsetting]
 type = "union"
@@ -164,9 +166,10 @@ longname = "unsaturated zone flow cell concentration status"
 description = "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value."
 
 [blocks.period.fields.uztperioddata.item.fields.uztsetting.arms.concentration]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to concentration."
+type = "string"
+longname = "unsaturated zone flow cell concentration"
+description = "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.uztperioddata.item.fields.uztsetting.arms.infiltration]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-uzt.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev2/gwt-uzt.yaml
@@ -133,6 +133,7 @@ blocks:
                 cell or the program will terminate with an error.  The program will also terminate with
                 an error if information for a UZF cell is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting UZF cell concentration
@@ -175,6 +176,7 @@ blocks:
                 the specified PERIOD data on the line. IFNO must be greater than zero and less than or
                 equal to NUZFCELLS.
               tagged: false
+              fk: packagedata.ifno
             uztsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -192,9 +194,14 @@ blocks:
                     the UZF cell concentration.  If a UZF cell is constant, then the concentration for
                     the UZF cell will be fixed at the user specified value.
                 concentration:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to concentration.
+                  type: string
+                  longname: unsaturated zone flow cell concentration
+                  description: real or character value that defines the concentration for the unsaturated
+                    zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone
+                    flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE
+                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
+                    series by entering the time-series name in place of a numeric value.
+                  time_series: true
                 infiltration:
                   type: string
                   longname: infiltration concentration

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-lke.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-lke.json
@@ -137,7 +137,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the lake number associated with the specified PACKAGEDATA data on the line. LAKENO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -191,7 +192,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the lake number associated with the specified PERIOD data on the line. LAKENO must be greater than zero and less than or equal to NLAKES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.lakeno"
               },
               "laksetting": {
                 "type": "union",
@@ -203,9 +205,10 @@
                     "description": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value."
                   },
                   "temperature": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to temperature."
+                    "type": "string",
+                    "longname": "lake temperature",
+                    "description": "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rainfall": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-lke.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-lke.toml
@@ -120,6 +120,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the lake number associated with the specified PACKAGEDATA data on the line. LAKENO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -168,6 +169,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the lake number associated with the specified PERIOD data on the line. LAKENO must be greater than zero and less than or equal to NLAKES."
 tagged = false
+fk = "packagedata.lakeno"
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting]
 type = "union"
@@ -179,9 +181,10 @@ longname = "lake temperature status"
 description = "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the lake.  If a lake is inactive, then there will be no energy fluxes into or out of the lake and the inactive value will be written for the lake temperature.  If a lake is constant, then the temperature for the lake will be fixed at the user specified value."
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting.arms.temperature]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to temperature."
+type = "string"
+longname = "lake temperature"
+description = "real or character value that defines the temperature for the lake. The specified TEMPERATURE is only applied if the lake is a constant temperature lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting.arms.rainfall]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-lke.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-lke.yaml
@@ -134,6 +134,7 @@ blocks:
                 program will also terminate with an error if information for a lake is specified more
                 than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting lake temperature
@@ -186,6 +187,7 @@ blocks:
               description: integer value that defines the lake number associated with the specified PERIOD
                 data on the line. LAKENO must be greater than zero and less than or equal to NLAKES.
               tagged: false
+              fk: packagedata.lakeno
             laksetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -206,9 +208,14 @@ blocks:
                     a lake is constant, then the temperature for the lake will be fixed at the user specified
                     value.
                 temperature:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to temperature.
+                  type: string
+                  longname: lake temperature
+                  description: real or character value that defines the temperature for the lake. The
+                    specified TEMPERATURE is only applied if the lake is a constant temperature lake.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rainfall:
                   type: string
                   longname: rainfall temperature

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-mwe.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-mwe.json
@@ -137,7 +137,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the well number associated with the specified PACKAGEDATA data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS. Well information must be specified for every well or the program will terminate with an error.  The program will also terminate with an error if information for a well is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -191,7 +192,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the well number associated with the specified PERIOD data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.mawno"
               },
               "mwesetting": {
                 "type": "union",
@@ -203,9 +205,10 @@
                     "description": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value."
                   },
                   "temperature": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to temperature."
+                    "type": "string",
+                    "longname": "well temperature",
+                    "description": "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rate": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-mwe.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-mwe.toml
@@ -120,6 +120,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the well number associated with the specified PACKAGEDATA data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS. Well information must be specified for every well or the program will terminate with an error.  The program will also terminate with an error if information for a well is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -168,6 +169,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the well number associated with the specified PERIOD data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS."
 tagged = false
+fk = "packagedata.mawno"
 
 [blocks.period.fields.mweperioddata.item.fields.mwesetting]
 type = "union"
@@ -179,9 +181,10 @@ longname = "well temperature status"
 description = "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well temperature.  If a well is constant, then the temperature for the well will be fixed at the user specified value."
 
 [blocks.period.fields.mweperioddata.item.fields.mwesetting.arms.temperature]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to temperature."
+type = "string"
+longname = "well temperature"
+description = "real or character value that defines the temperature for the well. The specified TEMPERATURE is only applied if the well is a constant temperature well. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.mweperioddata.item.fields.mwesetting.arms.rate]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-mwe.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-mwe.yaml
@@ -134,6 +134,7 @@ blocks:
                 error.  The program will also terminate with an error if information for a well is specified
                 more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting well temperature
@@ -186,6 +187,7 @@ blocks:
               description: integer value that defines the well number associated with the specified PERIOD
                 data on the line. MAWNO must be greater than zero and less than or equal to NMAWWELLS.
               tagged: false
+              fk: packagedata.mawno
             mwesetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -206,9 +208,14 @@ blocks:
                     a well is constant, then the temperature for the well will be fixed at the user specified
                     value.
                 temperature:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to temperature.
+                  type: string
+                  longname: well temperature
+                  description: real or character value that defines the temperature for the well. The
+                    specified TEMPERATURE is only applied if the well is a constant temperature well.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rate:
                   type: string
                   longname: well injection temperature

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-sfe.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-sfe.json
@@ -137,7 +137,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the reach number associated with the specified PACKAGEDATA data on the line. RNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -191,7 +192,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the reach number associated with the specified PERIOD data on the line. RNO must be greater than zero and less than or equal to NREACHES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.rno"
               },
               "reachsetting": {
                 "type": "union",
@@ -203,9 +205,10 @@
                     "description": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value."
                   },
                   "temperature": {
-                    "type": "keyword",
-                    "longname": "temperature keyword",
-                    "description": "keyword to specify that record corresponds to temperature."
+                    "type": "string",
+                    "longname": "reach temperature",
+                    "description": "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rainfall": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-sfe.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-sfe.toml
@@ -120,6 +120,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the reach number associated with the specified PACKAGEDATA data on the line. RNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -168,6 +169,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the reach number associated with the specified PERIOD data on the line. RNO must be greater than zero and less than or equal to NREACHES."
 tagged = false
+fk = "packagedata.rno"
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting]
 type = "union"
@@ -179,9 +181,10 @@ longname = "reach temperature status"
 description = "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the reach.  If a reach is inactive, then there will be no energy fluxes into or out of the reach and the inactive value will be written for the reach temperature.  If a reach is constant, then the temperature for the reach will be fixed at the user specified value."
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting.arms.temperature]
-type = "keyword"
-longname = "temperature keyword"
-description = "keyword to specify that record corresponds to temperature."
+type = "string"
+longname = "reach temperature"
+description = "real or character value that defines the temperature for the reach. The specified TEMPERATURE is only applied if the reach is a constant temperature reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting.arms.rainfall]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-sfe.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-sfe.yaml
@@ -135,6 +135,7 @@ blocks:
                 program will also terminate with an error if information for a reach is specified more
                 than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting reach temperature
@@ -187,6 +188,7 @@ blocks:
               description: integer value that defines the reach number associated with the specified PERIOD
                 data on the line. RNO must be greater than zero and less than or equal to NREACHES.
               tagged: false
+              fk: packagedata.rno
             reachsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -206,9 +208,14 @@ blocks:
                     a reach is constant, then the temperature for the reach will be fixed at the user
                     specified value.
                 temperature:
-                  type: keyword
-                  longname: temperature keyword
-                  description: keyword to specify that record corresponds to temperature.
+                  type: string
+                  longname: reach temperature
+                  description: real or character value that defines the temperature for the reach. The
+                    specified TEMPERATURE is only applied if the reach is a constant temperature reach.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rainfall:
                   type: string
                   longname: rainfall temperature

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-ssm.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-ssm.json
@@ -62,7 +62,7 @@
               "pname": {
                 "type": "string",
                 "longname": "package name",
-                "description": "name of the flow package for which an auxiliary variable contains a source temperature.  If this flow package is represented using an advanced transport package (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified here.",
+                "description": "name of the flow package for which an SPC6 input file contains a source temperature.  If this flow package is represented using an advanced transport package (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified here.",
                 "tagged": false
               },
               "spc6": {

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-ssm.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-ssm.toml
@@ -50,7 +50,7 @@ type = "record"
 [blocks.fileinput.fields.fileinput.item.fields.pname]
 type = "string"
 longname = "package name"
-description = "name of the flow package for which an auxiliary variable contains a source temperature.  If this flow package is represented using an advanced transport package (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified here."
+description = "name of the flow package for which an SPC6 input file contains a source temperature.  If this flow package is represented using an advanced transport package (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified here."
 tagged = false
 
 [blocks.fileinput.fields.fileinput.item.fields.spc6]

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-ssm.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-ssm.yaml
@@ -73,10 +73,9 @@ blocks:
             pname:
               type: string
               longname: package name
-              description: name of the flow package for which an auxiliary variable contains a source
-                temperature.  If this flow package is represented using an advanced transport package
-                (SFE, LKE, MWE, or UZE), then the advanced transport package will override SSM terms specified
-                here.
+              description: name of the flow package for which an SPC6 input file contains a source temperature.  If
+                this flow package is represented using an advanced transport package (SFE, LKE, MWE, or
+                UZE), then the advanced transport package will override SSM terms specified here.
               tagged: false
             spc6:
               type: keyword

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-uze.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-uze.json
@@ -137,7 +137,8 @@
                 "type": "integer",
                 "longname": "UZF cell number for this entry",
                 "description": "integer value that defines the UZF cell number associated with the specified PACKAGEDATA data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS. Unsaturated zone flow information must be specified for every UZF cell or the program will terminate with an error.  The program also will terminate with an error if information for a UZF cell is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -179,7 +180,8 @@
                 "type": "integer",
                 "longname": "unsaturated zone flow cell number for this entry",
                 "description": "integer value that defines the UZF cell number associated with the specified PERIOD data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.uzfno"
               },
               "uzesetting": {
                 "type": "union",
@@ -191,9 +193,10 @@
                     "description": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value."
                   },
                   "temperature": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to temperature."
+                    "type": "string",
+                    "longname": "unsaturated zone flow cell temperature",
+                    "description": "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "infiltration": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-uze.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-uze.toml
@@ -120,6 +120,7 @@ type = "integer"
 longname = "UZF cell number for this entry"
 description = "integer value that defines the UZF cell number associated with the specified PACKAGEDATA data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS. Unsaturated zone flow information must be specified for every UZF cell or the program will terminate with an error.  The program also will terminate with an error if information for a UZF cell is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -156,6 +157,7 @@ type = "integer"
 longname = "unsaturated zone flow cell number for this entry"
 description = "integer value that defines the UZF cell number associated with the specified PERIOD data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS."
 tagged = false
+fk = "packagedata.uzfno"
 
 [blocks.period.fields.uzeperioddata.item.fields.uzesetting]
 type = "union"
@@ -167,9 +169,10 @@ longname = "unsaturated zone flow cell temperature status"
 description = "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that temperature will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no energy fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell temperature.  If a UZF cell is constant, then the temperature for the UZF cell will be fixed at the user specified value."
 
 [blocks.period.fields.uzeperioddata.item.fields.uzesetting.arms.temperature]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to temperature."
+type = "string"
+longname = "unsaturated zone flow cell temperature"
+description = "real or character value that defines the temperature for the unsaturated zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.uzeperioddata.item.fields.uzesetting.arms.infiltration]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-uze.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwe-uze.yaml
@@ -135,6 +135,7 @@ blocks:
                 program will terminate with an error.  The program also will terminate with an error if
                 information for a UZF cell is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting UZF cell temperature
@@ -176,6 +177,7 @@ blocks:
               description: integer value that defines the UZF cell number associated with the specified
                 PERIOD data on the line. UZFNO must be greater than zero and less than or equal to NUZFCELLS.
               tagged: false
+              fk: packagedata.uzfno
             uzesetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -193,9 +195,14 @@ blocks:
                     temperature.  If a UZF cell is constant, then the temperature for the UZF cell will
                     be fixed at the user specified value.
                 temperature:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to temperature.
+                  type: string
+                  longname: unsaturated zone flow cell temperature
+                  description: real or character value that defines the temperature for the unsaturated
+                    zone flow cell. The specified TEMPERATURE is only applied if the unsaturated zone
+                    flow cell is a constant temperature cell. If the Options block includes a TIMESERIESFILE
+                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
+                    series by entering the time-series name in place of a numeric value.
+                  time_series: true
                 infiltration:
                   type: string
                   longname: infiltration temperature

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-lak.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-lak.json
@@ -204,7 +204,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -254,8 +255,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "lake number for this entry",
-                "description": "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (lake) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake connection information must be specified for every lake connection to the GWF model (NLAKECONN) or the program will terminate with an error.  The program will also terminate with an error if connection information for a lake connection to the GWF model is specified more than once.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "iconn": {
                 "type": "integer",
@@ -326,8 +328,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "lake number for this entry",
-                "description": "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (lake) number associated with the specified TABLES data on the line. IFNO must be greater than zero and less than or equal to NLAKES. The program will terminate with an error if table information for a lake is specified more than once or the number of specified tables is less than NTABLES.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "tab6": {
                 "type": "keyword",
@@ -365,19 +368,22 @@
                 "type": "integer",
                 "longname": "outlet number for this entry",
                 "description": "integer value that defines the outlet number associated with the specified OUTLETS data on the line. OUTLETNO must be greater than zero and less than or equal to NOUTLETS. Outlet information must be specified for every outlet or the program will terminate with an error. The program will also terminate with an error if information for a outlet is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "lakein": {
                 "type": "integer",
                 "longname": "lake number for upstream lake",
                 "description": "integer value that defines the lake number that outlet is connected to. LAKEIN must be greater than zero and less than or equal to NLAKES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "lakeout": {
                 "type": "integer",
                 "longname": "lake number for downstream lake",
                 "description": "integer value that defines the lake number that outlet discharge from lake outlet OUTLETNO is routed to. LAKEOUT must be greater than or equal to zero and less than or equal to NLAKES. If LAKEOUT is zero, outlet discharge from lake outlet OUTLETNO is discharged to an external boundary.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "couttype": {
                 "type": "string",
@@ -428,93 +434,235 @@
           "item": {
             "type": "record",
             "fields": {
-              "number": {
-                "type": "integer",
-                "longname": "lake or outlet number for this entry",
-                "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
-                "tagged": false
-              },
               "laksetting": {
                 "type": "union",
                 "description": "line of information that is parsed into a keyword and values.  Keyword values that can be used to start the LAKSETTING string include both keywords for lake settings and keywords for outlet settings.  Keywords for lake settings include: STATUS, STAGE, RAINFALL, EVAPORATION, RUNOFF, INFLOW, WITHDRAWAL, and AUXILIARY.  Keywords for outlet settings include RATE, INVERT, WIDTH, SLOPE, and ROUGH.",
                 "arms": {
                   "status": {
-                    "type": "string",
-                    "longname": "lake status",
-                    "description": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE."
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "status": {
+                        "type": "string",
+                        "longname": "lake status",
+                        "description": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE."
+                      }
+                    }
                   },
                   "stage": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to stage."
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "stage": {
+                        "type": "string",
+                        "longname": "lake stage",
+                        "description": "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "rainfall": {
-                    "type": "string",
-                    "longname": "rainfall rate",
-                    "description": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "rainfall": {
+                        "type": "string",
+                        "longname": "rainfall rate",
+                        "description": "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "evaporation": {
-                    "type": "string",
-                    "longname": "evaporation rate",
-                    "description": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "evaporation": {
+                        "type": "string",
+                        "longname": "evaporation rate",
+                        "description": "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "runoff": {
-                    "type": "string",
-                    "longname": "runoff rate",
-                    "description": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "runoff": {
+                        "type": "string",
+                        "longname": "runoff rate",
+                        "description": "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "inflow": {
-                    "type": "string",
-                    "longname": "inflow rate",
-                    "description": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "inflow": {
+                        "type": "string",
+                        "longname": "inflow rate",
+                        "description": "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "withdrawal": {
-                    "type": "string",
-                    "longname": "maximum withdrawal rate",
-                    "description": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
+                      "withdrawal": {
+                        "type": "string",
+                        "longname": "maximum withdrawal rate",
+                        "description": "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "rate": {
-                    "type": "string",
-                    "longname": "extraction rate",
-                    "description": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "rate": {
+                        "type": "string",
+                        "longname": "extraction rate",
+                        "description": "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "invert": {
-                    "type": "double",
-                    "longname": "invert elevation",
-                    "description": "real value that defines the invert elevation for the lake outlet. Any value can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "tagged": false,
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "invert": {
+                        "type": "string",
+                        "longname": "invert elevation",
+                        "description": "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "width": {
-                    "type": "double",
-                    "longname": "outlet width",
-                    "description": "real value that defines the width of the lake outlet. Any value can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "tagged": false,
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "width": {
+                        "type": "string",
+                        "longname": "outlet width",
+                        "description": "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "slope": {
-                    "type": "double",
-                    "longname": "bed slope",
-                    "description": "real value that defines the bed slope for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "tagged": false,
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "slope": {
+                        "type": "string",
+                        "longname": "bed slope",
+                        "description": "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "rough": {
-                    "type": "double",
-                    "longname": "roughness coefficient",
-                    "description": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
-                    "tagged": false,
-                    "time_series": true
+                    "type": "record",
+                    "fields": {
+                      "outletno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "outlets.outletno"
+                      },
+                      "rough": {
+                        "type": "string",
+                        "longname": "roughness coefficient",
+                        "description": "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                        "time_series": true
+                      }
+                    }
                   },
                   "auxiliaryrecord": {
                     "type": "record",
                     "fields": {
+                      "lakeno": {
+                        "type": "integer",
+                        "longname": "lake or outlet number for this entry",
+                        "description": "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number.",
+                        "tagged": false,
+                        "fk": "packagedata.ifno"
+                      },
                       "auxiliary": {
                         "type": "keyword",
                         "description": "keyword for specifying auxiliary variable."

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-lak.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-lak.toml
@@ -184,6 +184,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -227,8 +228,9 @@ type = "record"
 [blocks.connectiondata.fields.connectiondata.item.fields.ifno]
 type = "integer"
 longname = "lake number for this entry"
-description = "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
+description = "integer value that defines the feature (lake) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake connection information must be specified for every lake connection to the GWF model (NLAKECONN) or the program will terminate with an error.  The program will also terminate with an error if connection information for a lake connection to the GWF model is specified more than once."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.connectiondata.fields.connectiondata.item.fields.iconn]
 type = "integer"
@@ -293,8 +295,9 @@ type = "record"
 [blocks.tables.fields.tables.item.fields.ifno]
 type = "integer"
 longname = "lake number for this entry"
-description = "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
+description = "integer value that defines the feature (lake) number associated with the specified TABLES data on the line. IFNO must be greater than zero and less than or equal to NLAKES. The program will terminate with an error if table information for a lake is specified more than once or the number of specified tables is less than NTABLES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.tables.fields.tables.item.fields.tab6]
 type = "keyword"
@@ -327,18 +330,21 @@ type = "integer"
 longname = "outlet number for this entry"
 description = "integer value that defines the outlet number associated with the specified OUTLETS data on the line. OUTLETNO must be greater than zero and less than or equal to NOUTLETS. Outlet information must be specified for every outlet or the program will terminate with an error. The program will also terminate with an error if information for a outlet is specified more than once."
 tagged = false
+pk = true
 
 [blocks.outlets.fields.outlets.item.fields.lakein]
 type = "integer"
 longname = "lake number for upstream lake"
 description = "integer value that defines the lake number that outlet is connected to. LAKEIN must be greater than zero and less than or equal to NLAKES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.outlets.fields.outlets.item.fields.lakeout]
 type = "integer"
 longname = "lake number for downstream lake"
 description = "integer value that defines the lake number that outlet discharge from lake outlet OUTLETNO is routed to. LAKEOUT must be greater than or equal to zero and less than or equal to NLAKES. If LAKEOUT is zero, outlet discharge from lake outlet OUTLETNO is discharged to an external boundary."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.outlets.fields.outlets.item.fields.couttype]
 type = "string"
@@ -380,92 +386,210 @@ type = "list"
 [blocks.period.fields.perioddata.item]
 type = "record"
 
-[blocks.period.fields.perioddata.item.fields.number]
-type = "integer"
-longname = "lake or outlet number for this entry"
-description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
-tagged = false
-
 [blocks.period.fields.perioddata.item.fields.laksetting]
 type = "union"
 description = "line of information that is parsed into a keyword and values.  Keyword values that can be used to start the LAKSETTING string include both keywords for lake settings and keywords for outlet settings.  Keywords for lake settings include: STATUS, STAGE, RAINFALL, EVAPORATION, RUNOFF, INFLOW, WITHDRAWAL, and AUXILIARY.  Keywords for outlet settings include RATE, INVERT, WIDTH, SLOPE, and ROUGH."
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.status]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.status.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.status.fields.status]
 type = "string"
 longname = "lake status"
 description = "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE."
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.stage]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to stage."
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.stage.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.stage.fields.stage]
+type = "string"
+longname = "lake stage"
+description = "real or character value that defines the stage for the lake. The specified STAGE is only applied if the lake is a constant stage lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.rainfall]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rainfall.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rainfall.fields.rainfall]
 type = "string"
 longname = "rainfall rate"
 description = "real or character value that defines the rainfall rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.evaporation]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.evaporation.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.evaporation.fields.evaporation]
 type = "string"
 longname = "evaporation rate"
 description = "real or character value that defines the maximum evaporation rate $(LT^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.runoff]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.runoff.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.runoff.fields.runoff]
 type = "string"
 longname = "runoff rate"
 description = "real or character value that defines the runoff rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.inflow]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.inflow.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.inflow.fields.inflow]
 type = "string"
 longname = "inflow rate"
 description = "real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, inflow rates are zero for each lake."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.withdrawal]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.withdrawal.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.withdrawal.fields.withdrawal]
 type = "string"
 longname = "maximum withdrawal rate"
 description = "real or character value that defines the maximum withdrawal rate $(L^3 T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.rate]
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rate.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rate.fields.rate]
 type = "string"
 longname = "extraction rate"
 description = "real or character value that defines the extraction rate for the lake outflow. A positive value indicates inflow and a negative value indicates outflow from the lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.invert]
-type = "double"
-longname = "invert elevation"
-description = "real value that defines the invert elevation for the lake outlet. Any value can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.invert.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
 tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.invert.fields.invert]
+type = "string"
+longname = "invert elevation"
+description = "real or character value that defines the invert elevation for the lake outlet. A specified INVERT value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.width]
-type = "double"
-longname = "outlet width"
-description = "real value that defines the width of the lake outlet. Any value can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.width.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
 tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.width.fields.width]
+type = "string"
+longname = "outlet width"
+description = "real or character value that defines the width of the lake outlet. A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.slope]
-type = "double"
-longname = "bed slope"
-description = "real value that defines the bed slope for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.slope.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
 tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.slope.fields.slope]
+type = "string"
+longname = "bed slope"
+description = "real or character value that defines the bed slope for the lake outlet. A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.rough]
-type = "double"
+type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rough.fields.outletno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "outlets.outletno"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.rough.fields.rough]
+type = "string"
 longname = "roughness coefficient"
 description = "real value that defines the roughness coefficient for the lake outlet. Any value can be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
-tagged = false
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.auxiliaryrecord]
 type = "record"
+
+[blocks.period.fields.perioddata.item.fields.laksetting.arms.auxiliaryrecord.fields.lakeno]
+type = "integer"
+longname = "lake or outlet number for this entry"
+description = "integer value that defines the lake or outlet number associated with the specified PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for an outlet number."
+tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.perioddata.item.fields.laksetting.arms.auxiliaryrecord.fields.auxiliary]
 type = "keyword"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-lak.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-lak.yaml
@@ -203,6 +203,7 @@ blocks:
                 with an error.  The program will also terminate with an error if information for a lake
                 is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting lake stage
@@ -250,11 +251,13 @@ blocks:
               type: integer
               longname: lake number for this entry
               description: integer value that defines the feature (lake) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NLAKES. Lake information must be specified for every lake or the program will terminate
-                with an error.  The program will also terminate with an error if information for a lake
-                is specified more than once.
+                CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal
+                to NLAKES. Lake connection information must be specified for every lake connection to
+                the GWF model (NLAKECONN) or the program will terminate with an error.  The program will
+                also terminate with an error if connection information for a lake connection to the GWF
+                model is specified more than once.
               tagged: false
+              fk: packagedata.ifno
             iconn:
               type: integer
               longname: connection number for this entry
@@ -347,11 +350,11 @@ blocks:
               type: integer
               longname: lake number for this entry
               description: integer value that defines the feature (lake) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NLAKES. Lake information must be specified for every lake or the program will terminate
-                with an error.  The program will also terminate with an error if information for a lake
-                is specified more than once.
+                TABLES data on the line. IFNO must be greater than zero and less than or equal to NLAKES.
+                The program will terminate with an error if table information for a lake is specified
+                more than once or the number of specified tables is less than NTABLES.
               tagged: false
+              fk: packagedata.ifno
             tab6:
               type: keyword
               longname: head keyword
@@ -389,12 +392,14 @@ blocks:
                 with an error. The program will also terminate with an error if information for a outlet
                 is specified more than once.
               tagged: false
+              pk: true
             lakein:
               type: integer
               longname: lake number for upstream lake
               description: integer value that defines the lake number that outlet is connected to. LAKEIN
                 must be greater than zero and less than or equal to NLAKES.
               tagged: false
+              fk: packagedata.ifno
             lakeout:
               type: integer
               longname: lake number for downstream lake
@@ -403,6 +408,7 @@ blocks:
                 or equal to NLAKES. If LAKEOUT is zero, outlet discharge from lake outlet OUTLETNO is
                 discharged to an external boundary.
               tagged: false
+              fk: packagedata.ifno
             couttype:
               type: string
               longname: outlet type
@@ -457,13 +463,6 @@ blocks:
         item:
           type: record
           fields:
-            number:
-              type: integer
-              longname: lake or outlet number for this entry
-              description: integer value that defines the lake or outlet number associated with the specified
-                PERIOD data on the line.  NUMBER must be greater than zero and less than or equal to NLAKES
-                for a lake number and less than or equal to NOUTLETS for an outlet number.
-              tagged: false
             laksetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -473,106 +472,268 @@ blocks:
                 settings include RATE, INVERT, WIDTH, SLOPE, and ROUGH.'
               arms:
                 status:
-                  type: string
-                  longname: lake status
-                  description: keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE,
-                    or CONSTANT. By default, STATUS is ACTIVE.
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    status:
+                      type: string
+                      longname: lake status
+                      description: keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE,
+                        or CONSTANT. By default, STATUS is ACTIVE.
                 stage:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to stage.
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    stage:
+                      type: string
+                      longname: lake stage
+                      description: real or character value that defines the stage for the lake. The specified
+                        STAGE is only applied if the lake is a constant stage lake. If the Options block
+                        includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
+                        can be obtained from a time series by entering the time-series name in place of
+                        a numeric value.
+                      time_series: true
                 rainfall:
-                  type: string
-                  longname: rainfall rate
-                  description: real or character value that defines the rainfall rate $(LT^{-1})$ for
-                    the lake. Value must be greater than or equal to zero. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    rainfall:
+                      type: string
+                      longname: rainfall rate
+                      description: real or character value that defines the rainfall rate $(LT^{-1})$
+                        for the lake. Value must be greater than or equal to zero. If the Options block
+                        includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
+                        can be obtained from a time series by entering the time-series name in place of
+                        a numeric value.
+                      time_series: true
                 evaporation:
-                  type: string
-                  longname: evaporation rate
-                  description: real or character value that defines the maximum evaporation rate $(LT^{-1})$
-                    for the lake. Value must be greater than or equal to zero. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    evaporation:
+                      type: string
+                      longname: evaporation rate
+                      description: real or character value that defines the maximum evaporation rate $(LT^{-1})$
+                        for the lake. Value must be greater than or equal to zero. If the Options block
+                        includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
+                        can be obtained from a time series by entering the time-series name in place of
+                        a numeric value.
+                      time_series: true
                 runoff:
-                  type: string
-                  longname: runoff rate
-                  description: real or character value that defines the runoff rate $(L^3 T^{-1})$ for
-                    the lake. Value must be greater than or equal to zero. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    runoff:
+                      type: string
+                      longname: runoff rate
+                      description: real or character value that defines the runoff rate $(L^3 T^{-1})$
+                        for the lake. Value must be greater than or equal to zero. If the Options block
+                        includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
+                        can be obtained from a time series by entering the time-series name in place of
+                        a numeric value.
+                      time_series: true
                 inflow:
-                  type: string
-                  longname: inflow rate
-                  description: real or character value that defines the volumetric inflow rate $(L^3 T^{-1})$
-                    for the lake. Value must be greater than or equal to zero. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value. By
-                    default, inflow rates are zero for each lake.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    inflow:
+                      type: string
+                      longname: inflow rate
+                      description: real or character value that defines the volumetric inflow rate $(L^3
+                        T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options
+                        block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section),
+                        values can be obtained from a time series by entering the time-series name in
+                        place of a numeric value. By default, inflow rates are zero for each lake.
+                      time_series: true
                 withdrawal:
-                  type: string
-                  longname: maximum withdrawal rate
-                  description: real or character value that defines the maximum withdrawal rate $(L^3
-                    T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options
-                    block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values
-                    can be obtained from a time series by entering the time-series name in place of a
-                    numeric value.
-                  time_series: true
+                  type: record
+                  fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
+                    withdrawal:
+                      type: string
+                      longname: maximum withdrawal rate
+                      description: real or character value that defines the maximum withdrawal rate $(L^3
+                        T^{-1})$ for the lake. Value must be greater than or equal to zero. If the Options
+                        block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section),
+                        values can be obtained from a time series by entering the time-series name in
+                        place of a numeric value.
+                      time_series: true
                 rate:
-                  type: string
-                  longname: extraction rate
-                  description: real or character value that defines the extraction rate for the lake outflow.
-                    A positive value indicates inflow and a negative value indicates outflow from the
-                    lake. RATE only applies to outlets associated with active lakes (STATUS is ACTIVE).
-                    A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED. If the
-                    Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section),
-                    values can be obtained from a time series by entering the time-series name in place
-                    of a numeric value. By default, the RATE for each SPECIFIED lake outlet is zero.
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    rate:
+                      type: string
+                      longname: extraction rate
+                      description: real or character value that defines the extraction rate for the lake
+                        outflow. A positive value indicates inflow and a negative value indicates outflow
+                        from the lake. RATE only applies to outlets associated with active lakes (STATUS
+                        is ACTIVE). A specified RATE is only applied if COUTTYPE for the OUTLETNO is SPECIFIED.
+                        If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                        section), values can be obtained from a time series by entering the time-series
+                        name in place of a numeric value. By default, the RATE for each SPECIFIED lake
+                        outlet is zero.
+                      time_series: true
                 invert:
-                  type: double
-                  longname: invert elevation
-                  description: real value that defines the invert elevation for the lake outlet. Any value
-                    can be specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE
-                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
-                    series by entering the time-series name in place of a numeric value.
-                  tagged: false
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    invert:
+                      type: string
+                      longname: invert elevation
+                      description: real or character value that defines the invert elevation for the lake
+                        outlet. A specified INVERT value is only used for active lakes if COUTTYPE for
+                        lake outlet OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE
+                        entry (see the 'Time-Variable Input' section), values can be obtained from a time
+                        series by entering the time-series name in place of a numeric value.
+                      time_series: true
                 width:
-                  type: double
-                  longname: outlet width
-                  description: real value that defines the width of the lake outlet. Any value can be
-                    specified if COUTTYPE is SPECIFIED. If the Options block includes a TIMESERIESFILE
-                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
-                    series by entering the time-series name in place of a numeric value.
-                  tagged: false
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    width:
+                      type: string
+                      longname: outlet width
+                      description: real or character value that defines the width of the lake outlet.
+                        A specified WIDTH value is only used for active lakes if COUTTYPE for lake outlet
+                        OUTLETNO is not SPECIFIED. If the Options block includes a TIMESERIESFILE entry
+                        (see the 'Time-Variable Input' section), values can be obtained from a time series
+                        by entering the time-series name in place of a numeric value.
+                      time_series: true
                 slope:
-                  type: double
-                  longname: bed slope
-                  description: real value that defines the bed slope for the lake outlet. Any value can
-                    be specified if COUTTYPE is not MANNING. If the Options block includes a TIMESERIESFILE
-                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
-                    series by entering the time-series name in place of a numeric value.
-                  tagged: false
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    slope:
+                      type: string
+                      longname: bed slope
+                      description: real or character value that defines the bed slope for the lake outlet.
+                        A specified SLOPE value is only used for active lakes if COUTTYPE for lake outlet
+                        OUTLETNO is MANNING. If the Options block includes a TIMESERIESFILE entry (see
+                        the 'Time-Variable Input' section), values can be obtained from a time series
+                        by entering the time-series name in place of a numeric value.
+                      time_series: true
                 rough:
-                  type: double
-                  longname: roughness coefficient
-                  description: real value that defines the roughness coefficient for the lake outlet.
-                    Any value can be specified if COUTTYPE is not MANNING. If the Options block includes
-                    a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained
-                    from a time series by entering the time-series name in place of a numeric value.
-                  tagged: false
-                  time_series: true
+                  type: record
+                  fields:
+                    outletno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: outlets.outletno
+                    rough:
+                      type: string
+                      longname: roughness coefficient
+                      description: real value that defines the roughness coefficient for the lake outlet.
+                        Any value can be specified if COUTTYPE is not MANNING. If the Options block includes
+                        a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be
+                        obtained from a time series by entering the time-series name in place of a numeric
+                        value.
+                      time_series: true
                 auxiliaryrecord:
                   type: record
                   fields:
+                    lakeno:
+                      type: integer
+                      longname: lake or outlet number for this entry
+                      description: integer value that defines the lake or outlet number associated with
+                        the specified PERIOD data on the line.  NUMBER must be greater than zero and less
+                        than or equal to NLAKES for a lake number and less than or equal to NOUTLETS for
+                        an outlet number.
+                      tagged: false
+                      fk: packagedata.ifno
                     auxiliary:
                       type: keyword
                       description: keyword for specifying auxiliary variable.

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-maw.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-maw.json
@@ -182,7 +182,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well or the program will terminate with an error.  The program will also terminate with an error if information for a multi-aquifer well is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "radius": {
                 "type": "double",
@@ -250,8 +251,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "well number for this entry",
-                "description": "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well or the program will terminate with an error.  The program will also terminate with an error if information for a multi-aquifer well is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (well) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well connection information must be specified for every multi-aquifer well connection to the GWF model (NGWFNODES) or the program will terminate with an error.  The program will also terminate with an error if connection information for a multi-aquifer well connection to the GWF model is specified more than once.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "icon": {
                 "type": "integer",
@@ -308,7 +310,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the well number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "mawsetting": {
                 "type": "union",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-maw.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-maw.toml
@@ -162,6 +162,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well or the program will terminate with an error.  The program will also terminate with an error if information for a multi-aquifer well is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.radius]
 type = "double"
@@ -220,8 +221,9 @@ type = "record"
 [blocks.connectiondata.fields.connectiondata.item.fields.ifno]
 type = "integer"
 longname = "well number for this entry"
-description = "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well or the program will terminate with an error.  The program will also terminate with an error if information for a multi-aquifer well is specified more than once."
+description = "integer value that defines the feature (well) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Multi-aquifer well connection information must be specified for every multi-aquifer well connection to the GWF model (NGWFNODES) or the program will terminate with an error.  The program will also terminate with an error if connection information for a multi-aquifer well connection to the GWF model is specified more than once."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.connectiondata.fields.connectiondata.item.fields.icon]
 type = "integer"
@@ -273,6 +275,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the well number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.perioddata.item.fields.mawsetting]
 type = "union"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-maw.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-maw.yaml
@@ -188,6 +188,7 @@ blocks:
                 or the program will terminate with an error.  The program will also terminate with an
                 error if information for a multi-aquifer well is specified more than once.
               tagged: false
+              pk: true
             radius:
               type: double
               longname: well radius
@@ -274,11 +275,13 @@ blocks:
               type: integer
               longname: well number for this entry
               description: integer value that defines the feature (well) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NMAWWELLS. Multi-aquifer well information must be specified for every multi-aquifer well
-                or the program will terminate with an error.  The program will also terminate with an
-                error if information for a multi-aquifer well is specified more than once.
+                CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal
+                to NMAWWELLS. Multi-aquifer well connection information must be specified for every multi-aquifer
+                well connection to the GWF model (NGWFNODES) or the program will terminate with an error.  The
+                program will also terminate with an error if connection information for a multi-aquifer
+                well connection to the GWF model is specified more than once.
               tagged: false
+              fk: packagedata.ifno
             icon:
               type: integer
               longname: connection number
@@ -355,6 +358,7 @@ blocks:
               description: integer value that defines the well number associated with the specified PERIOD
                 data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS.
               tagged: false
+              fk: packagedata.ifno
             mawsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-sfr.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-sfr.json
@@ -314,8 +314,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "reach number for this entry",
-                "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (reach) number associated with the specified cross-section table file on the line. IFNO must be greater than zero and less than or equal to NREACHES. The program will also terminate with an error if table information for a reach is specified more than once.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "tab6": {
                 "type": "keyword",
@@ -349,7 +350,7 @@
               "ifno": {
                 "type": "integer",
                 "longname": "reach number for this entry",
-                "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
+                "description": "integer value that defines the feature (reach) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach connection information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if connection information for a reach is specified more than once.",
                 "tagged": false,
                 "fk": "packagedata.ifno"
               },
@@ -378,8 +379,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "reach number for this entry",
-                "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (reach) number associated with the specified DIVERSIONS data on the line. IFNO must be greater than zero and less than or equal to NREACHES.  Reach diversion information must be specified for every reach with a NDV value greater than 0 or the program will terminate with an error.  The program will also terminate with an error if diversion information for a given reach diversion is specified more than once.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "idv": {
                 "type": "integer",
@@ -414,8 +416,9 @@
               "ifno": {
                 "type": "integer",
                 "longname": "reach number for this entry",
-                "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "description": "integer value that defines the feature (reach) number associated with the specified initial stage. Initial stage data must be specified for every reach or the program will terminate with an error. The program will also terminate with a error if IFNO is less than one or greater than NREACHES.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "initialstage": {
                 "type": "double",
@@ -439,7 +442,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the feature (reach) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "sfrsetting": {
                 "type": "union",
@@ -463,9 +467,10 @@
                     "time_series": true
                   },
                   "stage": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to stage."
+                    "type": "string",
+                    "longname": "reach stage",
+                    "description": "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "inflow": {
                     "type": "string",
@@ -501,8 +506,8 @@
                       },
                       "idv": {
                         "type": "integer",
-                        "longname": "downstream diversion number",
-                        "description": "integer value that defines the downstream diversion number for the diversion for reach IFNO. IDV must be greater than zero and less than or equal to NDV for reach IFNO.",
+                        "longname": "diversion number",
+                        "description": "an integer value specifying which diversion of reach IFNO that DIVFLOW is being specified for.  Must be less or equal to ndv for the current reach (IFNO).",
                         "tagged": false
                       },
                       "divflow": {

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-sfr.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-sfr.toml
@@ -284,8 +284,9 @@ type = "record"
 [blocks.crosssections.fields.crosssections.item.fields.ifno]
 type = "integer"
 longname = "reach number for this entry"
-description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
+description = "integer value that defines the feature (reach) number associated with the specified cross-section table file on the line. IFNO must be greater than zero and less than or equal to NREACHES. The program will also terminate with an error if table information for a reach is specified more than once."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.crosssections.fields.crosssections.item.fields.tab6]
 type = "keyword"
@@ -313,7 +314,7 @@ type = "record"
 [blocks.connectiondata.fields.connectiondata.item.fields.ifno]
 type = "integer"
 longname = "reach number for this entry"
-description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
+description = "integer value that defines the feature (reach) number associated with the specified CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach connection information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if connection information for a reach is specified more than once."
 tagged = false
 fk = "packagedata.ifno"
 
@@ -336,8 +337,9 @@ type = "record"
 [blocks.diversions.fields.diversions.item.fields.ifno]
 type = "integer"
 longname = "reach number for this entry"
-description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
+description = "integer value that defines the feature (reach) number associated with the specified DIVERSIONS data on the line. IFNO must be greater than zero and less than or equal to NREACHES.  Reach diversion information must be specified for every reach with a NDV value greater than 0 or the program will terminate with an error.  The program will also terminate with an error if diversion information for a given reach diversion is specified more than once."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.diversions.fields.diversions.item.fields.idv]
 type = "integer"
@@ -366,8 +368,9 @@ type = "record"
 [blocks.initialstages.fields.initialstages.item.fields.ifno]
 type = "integer"
 longname = "reach number for this entry"
-description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
+description = "integer value that defines the feature (reach) number associated with the specified initial stage. Initial stage data must be specified for every reach or the program will terminate with an error. The program will also terminate with a error if IFNO is less than one or greater than NREACHES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.initialstages.fields.initialstages.item.fields.initialstage]
 type = "double"
@@ -386,6 +389,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the feature (reach) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting]
 type = "union"
@@ -409,9 +413,10 @@ description = "real or character value that defines the Manning's roughness coef
 time_series = true
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting.arms.stage]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to stage."
+type = "string"
+longname = "reach stage"
+description = "real or character value that defines the stage for the reach. The specified STAGE is only applied if the reach uses the simple routing option. If STAGE is not specified for reaches that use the simple routing option, the specified stage is set to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting.arms.inflow]
 type = "string"
@@ -447,8 +452,8 @@ description = "keyword to indicate diversion record."
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting.arms.diversionrecord.fields.idv]
 type = "integer"
-longname = "downstream diversion number"
-description = "integer value that defines the downstream diversion number for the diversion for reach IFNO. IDV must be greater than zero and less than or equal to NDV for reach IFNO."
+longname = "diversion number"
+description = "an integer value specifying which diversion of reach IFNO that DIVFLOW is being specified for.  Must be less or equal to ndv for the current reach (IFNO)."
 tagged = false
 
 [blocks.period.fields.perioddata.item.fields.sfrsetting.arms.diversionrecord.fields.divflow]

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-sfr.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-sfr.yaml
@@ -331,11 +331,11 @@ blocks:
               type: integer
               longname: reach number for this entry
               description: integer value that defines the feature (reach) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NREACHES. Reach information must be specified for every reach or the program will terminate
-                with an error.  The program will also terminate with an error if information for a reach
-                is specified more than once.
+                cross-section table file on the line. IFNO must be greater than zero and less than or
+                equal to NREACHES. The program will also terminate with an error if table information
+                for a reach is specified more than once.
               tagged: false
+              fk: packagedata.ifno
             tab6:
               type: keyword
               longname: head keyword
@@ -365,10 +365,10 @@ blocks:
               type: integer
               longname: reach number for this entry
               description: integer value that defines the feature (reach) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NREACHES. Reach information must be specified for every reach or the program will terminate
-                with an error.  The program will also terminate with an error if information for a reach
-                is specified more than once.
+                CONNECTIONDATA data on the line. IFNO must be greater than zero and less than or equal
+                to NREACHES. Reach connection information must be specified for every reach or the program
+                will terminate with an error.  The program will also terminate with an error if connection
+                information for a reach is specified more than once.
               tagged: false
               fk: packagedata.ifno
             ic:
@@ -396,11 +396,13 @@ blocks:
               type: integer
               longname: reach number for this entry
               description: integer value that defines the feature (reach) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NREACHES. Reach information must be specified for every reach or the program will terminate
-                with an error.  The program will also terminate with an error if information for a reach
-                is specified more than once.
+                DIVERSIONS data on the line. IFNO must be greater than zero and less than or equal to
+                NREACHES.  Reach diversion information must be specified for every reach with a NDV value
+                greater than 0 or the program will terminate with an error.  The program will also terminate
+                with an error if diversion information for a given reach diversion is specified more than
+                once.
               tagged: false
+              fk: packagedata.ifno
             idv:
               type: integer
               longname: downstream diversion number
@@ -449,11 +451,11 @@ blocks:
               type: integer
               longname: reach number for this entry
               description: integer value that defines the feature (reach) number associated with the specified
-                PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to
-                NREACHES. Reach information must be specified for every reach or the program will terminate
-                with an error.  The program will also terminate with an error if information for a reach
-                is specified more than once.
+                initial stage. Initial stage data must be specified for every reach or the program will
+                terminate with an error. The program will also terminate with a error if IFNO is less
+                than one or greater than NREACHES.
               tagged: false
+              fk: packagedata.ifno
             initialstage:
               type: double
               longname: initial reach stage
@@ -476,6 +478,7 @@ blocks:
               description: integer value that defines the feature (reach) number associated with the specified
                 PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES.
               tagged: false
+              fk: packagedata.ifno
             sfrsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -515,9 +518,15 @@ blocks:
                     from a time series by entering the time-series name in place of a numeric value.
                   time_series: true
                 stage:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to stage.
+                  type: string
+                  longname: reach stage
+                  description: real or character value that defines the stage for the reach. The specified
+                    STAGE is only applied if the reach uses the simple routing option. If STAGE is not
+                    specified for reaches that use the simple routing option, the specified stage is set
+                    to the top of the reach. If the Options block includes a TIMESERIESFILE entry (see
+                    the 'Time-Variable Input' section), values can be obtained from a time series by entering
+                    the time-series name in place of a numeric value.
+                  time_series: true
                 inflow:
                   type: string
                   longname: inflow rate
@@ -570,10 +579,9 @@ blocks:
                       description: keyword to indicate diversion record.
                     idv:
                       type: integer
-                      longname: downstream diversion number
-                      description: integer value that defines the downstream diversion number for the
-                        diversion for reach IFNO. IDV must be greater than zero and less than or equal
-                        to NDV for reach IFNO.
+                      longname: diversion number
+                      description: an integer value specifying which diversion of reach IFNO that DIVFLOW
+                        is being specified for.  Must be less or equal to ndv for the current reach (IFNO).
                       tagged: false
                     divflow:
                       type: double

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-uzf.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-uzf.json
@@ -207,7 +207,8 @@
                 "type": "integer",
                 "longname": "uzf id number for this entry",
                 "description": "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "cellid": {
                 "type": "array",
@@ -290,9 +291,10 @@
             "fields": {
               "ifno": {
                 "type": "integer",
-                "longname": "uzf id number for this entry",
-                "description": "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once.",
-                "tagged": false
+                "longname": "UZF id number",
+                "description": "integer value that defines the feature (UZF object) number associated with the specified PERIOD data on the line.",
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "finf": {
                 "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-uzf.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-uzf.toml
@@ -187,6 +187,7 @@ type = "integer"
 longname = "uzf id number for this entry"
 description = "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.cellid]
 type = "array"
@@ -260,9 +261,10 @@ type = "record"
 
 [blocks.period.fields.perioddata.item.fields.ifno]
 type = "integer"
-longname = "uzf id number for this entry"
-description = "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once."
+longname = "UZF id number"
+description = "integer value that defines the feature (UZF object) number associated with the specified PERIOD data on the line."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.perioddata.item.fields.finf]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-uzf.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwf-uzf.yaml
@@ -204,6 +204,7 @@ blocks:
                 will terminate with an error.  The program will also terminate with an error if information
                 for a UZF cell is specified more than once.
               tagged: false
+              pk: true
             cellid:
               type: array
               longname: cell identifier
@@ -288,13 +289,11 @@ blocks:
           fields:
             ifno:
               type: integer
-              longname: uzf id number for this entry
+              longname: UZF id number
               description: integer value that defines the feature (UZF object) number associated with
-                the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than
-                or equal to NUZFCELLS.  UZF information must be specified for every UZF cell or the program
-                will terminate with an error.  The program will also terminate with an error if information
-                for a UZF cell is specified more than once.
+                the specified PERIOD data on the line.
               tagged: false
+              fk: packagedata.ifno
             finf:
               type: string
               longname: infiltration rate

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-lkt.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-lkt.json
@@ -137,7 +137,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -179,7 +180,8 @@
                 "type": "integer",
                 "longname": "lake number for this entry",
                 "description": "integer value that defines the feature (lake) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NLAKES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "laksetting": {
                 "type": "union",
@@ -191,9 +193,10 @@
                     "description": "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value."
                   },
                   "concentration": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to concentration."
+                    "type": "string",
+                    "longname": "lake concentration",
+                    "description": "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rainfall": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-lkt.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-lkt.toml
@@ -120,6 +120,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the feature (lake) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NLAKES. Lake information must be specified for every lake or the program will terminate with an error.  The program will also terminate with an error if information for a lake is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -156,6 +157,7 @@ type = "integer"
 longname = "lake number for this entry"
 description = "integer value that defines the feature (lake) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NLAKES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting]
 type = "union"
@@ -167,9 +169,10 @@ longname = "lake concentration status"
 description = "keyword option to define lake status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the lake.  If a lake is inactive, then there will be no solute mass fluxes into or out of the lake and the inactive value will be written for the lake concentration.  If a lake is constant, then the concentration for the lake will be fixed at the user specified value."
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting.arms.concentration]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to concentration."
+type = "string"
+longname = "lake concentration"
+description = "real or character value that defines the concentration for the lake. The specified CONCENTRATION is only applied if the lake is a constant concentration lake. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.lakeperioddata.item.fields.laksetting.arms.rainfall]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-lkt.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-lkt.yaml
@@ -134,6 +134,7 @@ blocks:
                 with an error.  The program will also terminate with an error if information for a lake
                 is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting lake concentration
@@ -174,6 +175,7 @@ blocks:
               description: integer value that defines the feature (lake) number associated with the specified
                 PERIOD data on the line. IFNO must be greater than zero and less than or equal to NLAKES.
               tagged: false
+              fk: packagedata.ifno
             laksetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -194,9 +196,14 @@ blocks:
                     concentration.  If a lake is constant, then the concentration for the lake will be
                     fixed at the user specified value.
                 concentration:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to concentration.
+                  type: string
+                  longname: lake concentration
+                  description: real or character value that defines the concentration for the lake. The
+                    specified CONCENTRATION is only applied if the lake is a constant concentration lake.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rainfall:
                   type: string
                   longname: rainfall concentration

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-mwt.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-mwt.json
@@ -137,7 +137,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Well information must be specified for every well or the program will terminate with an error.  The program will also terminate with an error if information for a well is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -179,7 +180,8 @@
                 "type": "integer",
                 "longname": "well number for this entry",
                 "description": "integer value that defines the feature (well) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "mwtsetting": {
                 "type": "union",
@@ -191,9 +193,10 @@
                     "description": "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value."
                   },
                   "concentration": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to concentration."
+                    "type": "string",
+                    "longname": "well concentration",
+                    "description": "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rate": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-mwt.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-mwt.toml
@@ -120,6 +120,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the feature (well) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS. Well information must be specified for every well or the program will terminate with an error.  The program will also terminate with an error if information for a well is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -156,6 +157,7 @@ type = "integer"
 longname = "well number for this entry"
 description = "integer value that defines the feature (well) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.mwtperioddata.item.fields.mwtsetting]
 type = "union"
@@ -167,9 +169,10 @@ longname = "well concentration status"
 description = "keyword option to define well status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the well.  If a well is inactive, then there will be no solute mass fluxes into or out of the well and the inactive value will be written for the well concentration.  If a well is constant, then the concentration for the well will be fixed at the user specified value."
 
 [blocks.period.fields.mwtperioddata.item.fields.mwtsetting.arms.concentration]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to concentration."
+type = "string"
+longname = "well concentration"
+description = "real or character value that defines the concentration for the well. The specified CONCENTRATION is only applied if the well is a constant concentration well. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.mwtperioddata.item.fields.mwtsetting.arms.rate]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-mwt.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-mwt.yaml
@@ -134,6 +134,7 @@ blocks:
                 with an error.  The program will also terminate with an error if information for a well
                 is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting well concentration
@@ -174,6 +175,7 @@ blocks:
               description: integer value that defines the feature (well) number associated with the specified
                 PERIOD data on the line. IFNO must be greater than zero and less than or equal to NMAWWELLS.
               tagged: false
+              fk: packagedata.ifno
             mwtsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -194,9 +196,14 @@ blocks:
                     concentration.  If a well is constant, then the concentration for the well will be
                     fixed at the user specified value.
                 concentration:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to concentration.
+                  type: string
+                  longname: well concentration
+                  description: real or character value that defines the concentration for the well. The
+                    specified CONCENTRATION is only applied if the well is a constant concentration well.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rate:
                   type: string
                   longname: well injection concentration

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-sft.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-sft.json
@@ -137,7 +137,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -179,7 +180,8 @@
                 "type": "integer",
                 "longname": "reach number for this entry",
                 "description": "integer value that defines the feature (reach) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "reachsetting": {
                 "type": "union",
@@ -191,9 +193,10 @@
                     "description": "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value."
                   },
                   "concentration": {
-                    "type": "keyword",
-                    "longname": "concentration keyword",
-                    "description": "keyword to specify that record corresponds to concentration."
+                    "type": "string",
+                    "longname": "reach concentration",
+                    "description": "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "rainfall": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-sft.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-sft.toml
@@ -120,6 +120,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the feature (reach) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NREACHES. Reach information must be specified for every reach or the program will terminate with an error.  The program will also terminate with an error if information for a reach is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -156,6 +157,7 @@ type = "integer"
 longname = "reach number for this entry"
 description = "integer value that defines the feature (reach) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting]
 type = "union"
@@ -167,9 +169,10 @@ longname = "reach concentration status"
 description = "keyword option to define reach status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the reach.  If a reach is inactive, then there will be no solute mass fluxes into or out of the reach and the inactive value will be written for the reach concentration.  If a reach is constant, then the concentration for the reach will be fixed at the user specified value."
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting.arms.concentration]
-type = "keyword"
-longname = "concentration keyword"
-description = "keyword to specify that record corresponds to concentration."
+type = "string"
+longname = "reach concentration"
+description = "real or character value that defines the concentration for the reach. The specified CONCENTRATION is only applied if the reach is a constant concentration reach. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.reachperioddata.item.fields.reachsetting.arms.rainfall]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-sft.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-sft.yaml
@@ -134,6 +134,7 @@ blocks:
                 with an error.  The program will also terminate with an error if information for a reach
                 is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting reach concentration
@@ -174,6 +175,7 @@ blocks:
               description: integer value that defines the feature (reach) number associated with the specified
                 PERIOD data on the line. IFNO must be greater than zero and less than or equal to NREACHES.
               tagged: false
+              fk: packagedata.ifno
             reachsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -193,9 +195,14 @@ blocks:
                     concentration.  If a reach is constant, then the concentration for the reach will
                     be fixed at the user specified value.
                 concentration:
-                  type: keyword
-                  longname: concentration keyword
-                  description: keyword to specify that record corresponds to concentration.
+                  type: string
+                  longname: reach concentration
+                  description: real or character value that defines the concentration for the reach. The
+                    specified CONCENTRATION is only applied if the reach is a constant concentration reach.
+                    If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input'
+                    section), values can be obtained from a time series by entering the time-series name
+                    in place of a numeric value.
+                  time_series: true
                 rainfall:
                   type: string
                   longname: rainfall concentration

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-ssm.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-ssm.json
@@ -62,7 +62,7 @@
               "pname": {
                 "type": "string",
                 "longname": "package name",
-                "description": "name of the flow package for which an auxiliary variable contains a source concentration.  If this flow package is represented using an advanced transport package (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified here.",
+                "description": "name of the flow package for which an SPC6 input file contains a source concentration.  If this flow package is represented using an advanced transport package (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified here.",
                 "tagged": false
               },
               "spc6": {

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-ssm.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-ssm.toml
@@ -50,7 +50,7 @@ type = "record"
 [blocks.fileinput.fields.fileinput.item.fields.pname]
 type = "string"
 longname = "package name"
-description = "name of the flow package for which an auxiliary variable contains a source concentration.  If this flow package is represented using an advanced transport package (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified here."
+description = "name of the flow package for which an SPC6 input file contains a source concentration.  If this flow package is represented using an advanced transport package (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified here."
 tagged = false
 
 [blocks.fileinput.fields.fileinput.item.fields.spc6]

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-ssm.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-ssm.yaml
@@ -73,10 +73,9 @@ blocks:
             pname:
               type: string
               longname: package name
-              description: name of the flow package for which an auxiliary variable contains a source
-                concentration.  If this flow package is represented using an advanced transport package
-                (SFT, LKT, MWT, or UZT), then the advanced transport package will override SSM terms specified
-                here.
+              description: name of the flow package for which an SPC6 input file contains a source concentration.  If
+                this flow package is represented using an advanced transport package (SFT, LKT, MWT, or
+                UZT), then the advanced transport package will override SSM terms specified here.
               tagged: false
             spc6:
               type: keyword

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-uzt.json
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-uzt.json
@@ -137,7 +137,8 @@
                 "type": "integer",
                 "longname": "UZF cell number for this entry",
                 "description": "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS. Unsaturated zone flow information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once.",
-                "tagged": false
+                "tagged": false,
+                "pk": true
               },
               "strt": {
                 "type": "double",
@@ -179,7 +180,8 @@
                 "type": "integer",
                 "longname": "unsaturated zone flow cell number for this entry",
                 "description": "integer value that defines the feature (UZF object) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS.",
-                "tagged": false
+                "tagged": false,
+                "fk": "packagedata.ifno"
               },
               "uztsetting": {
                 "type": "union",
@@ -191,9 +193,10 @@
                     "description": "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value."
                   },
                   "concentration": {
-                    "type": "keyword",
-                    "longname": "stage keyword",
-                    "description": "keyword to specify that record corresponds to concentration."
+                    "type": "string",
+                    "longname": "unsaturated zone flow cell concentration",
+                    "description": "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value.",
+                    "time_series": true
                   },
                   "infiltration": {
                     "type": "string",

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-uzt.toml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-uzt.toml
@@ -120,6 +120,7 @@ type = "integer"
 longname = "UZF cell number for this entry"
 description = "integer value that defines the feature (UZF object) number associated with the specified PACKAGEDATA data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS. Unsaturated zone flow information must be specified for every UZF cell or the program will terminate with an error.  The program will also terminate with an error if information for a UZF cell is specified more than once."
 tagged = false
+pk = true
 
 [blocks.packagedata.fields.packagedata.item.fields.strt]
 type = "double"
@@ -156,6 +157,7 @@ type = "integer"
 longname = "unsaturated zone flow cell number for this entry"
 description = "integer value that defines the feature (UZF object) number associated with the specified PERIOD data on the line. IFNO must be greater than zero and less than or equal to NUZFCELLS."
 tagged = false
+fk = "packagedata.ifno"
 
 [blocks.period.fields.uztperioddata.item.fields.uztsetting]
 type = "union"
@@ -167,9 +169,10 @@ longname = "unsaturated zone flow cell concentration status"
 description = "keyword option to define UZF cell status.  STATUS can be ACTIVE, INACTIVE, or CONSTANT. By default, STATUS is ACTIVE, which means that concentration will be calculated for the UZF cell.  If a UZF cell is inactive, then there will be no solute mass fluxes into or out of the UZF cell and the inactive value will be written for the UZF cell concentration.  If a UZF cell is constant, then the concentration for the UZF cell will be fixed at the user specified value."
 
 [blocks.period.fields.uztperioddata.item.fields.uztsetting.arms.concentration]
-type = "keyword"
-longname = "stage keyword"
-description = "keyword to specify that record corresponds to concentration."
+type = "string"
+longname = "unsaturated zone flow cell concentration"
+description = "real or character value that defines the concentration for the unsaturated zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE entry (see the 'Time-Variable Input' section), values can be obtained from a time series by entering the time-series name in place of a numeric value."
+time_series = true
 
 [blocks.period.fields.uztperioddata.item.fields.uztsetting.arms.infiltration]
 type = "string"

--- a/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-uzt.yaml
+++ b/autotest/dfns/__snapshots__/v2.0.0.dev3/gwt-uzt.yaml
@@ -135,6 +135,7 @@ blocks:
                 cell or the program will terminate with an error.  The program will also terminate with
                 an error if information for a UZF cell is specified more than once.
               tagged: false
+              pk: true
             strt:
               type: double
               longname: starting UZF cell concentration
@@ -177,6 +178,7 @@ blocks:
                 the specified PERIOD data on the line. IFNO must be greater than zero and less than or
                 equal to NUZFCELLS.
               tagged: false
+              fk: packagedata.ifno
             uztsetting:
               type: union
               description: 'line of information that is parsed into a keyword and values.  Keyword values
@@ -194,9 +196,14 @@ blocks:
                     the UZF cell concentration.  If a UZF cell is constant, then the concentration for
                     the UZF cell will be fixed at the user specified value.
                 concentration:
-                  type: keyword
-                  longname: stage keyword
-                  description: keyword to specify that record corresponds to concentration.
+                  type: string
+                  longname: unsaturated zone flow cell concentration
+                  description: real or character value that defines the concentration for the unsaturated
+                    zone flow cell. The specified CONCENTRATION is only applied if the unsaturated zone
+                    flow cell is a constant concentration cell. If the Options block includes a TIMESERIESFILE
+                    entry (see the 'Time-Variable Input' section), values can be obtained from a time
+                    series by entering the time-series name in place of a numeric value.
+                  time_series: true
                 infiltration:
                   type: string
                   longname: infiltration concentration

--- a/docs/md/dfnspec.md
+++ b/docs/md/dfnspec.md
@@ -82,7 +82,7 @@ This document describes the MODFLOW 6 component definition (DFN) system. This sy
   - [Dimensions](#dimensions)
     - [Dimension sources](#dimension-sources)
     - [Dimension scope](#dimension-scope)
-  - [Primary/foreign keys](#primaryforeign-keys)
+  - [Primary/foreign keys](#primary-and-foreign-keys)
     - [Examples](#examples)
 - [Memory catalog](#memory-catalog)
   - [Attributes](#attributes-1)
@@ -638,7 +638,7 @@ Examples:
 - `gwf-dis.dims.nrow`, `ncol`, `nlay` have `scope: "model"`: accessible to `gwf-chd`, `gwf-wel`, and any other component whose parent is `gwf-nam`, but also to e.g. `utl-spca` (which has `parent: "package"`).
 - `sim-tdis.dims.nper` has `scope: "simulation"`: accessible from all components.
 
-### Primary/foreign keys
+### Primary and foreign keys
 
 Sometimes a column in one list identifies a row in another list, or a grid cell. This can be conceptualized as a primary key (PK) / foreign key (FK) relation. Integers and strings may encode PK/FK semantics with attributes `pk`, `fk`, and `fk_ref`.
 
@@ -646,13 +646,13 @@ Sometimes a column in one list identifies a row in another list, or a grid cell.
 
 The `fk` attribute can take one of three forms:
 
-- **Hierarchical path** — `"block.field"` for within-component references, `"component.block.field"` for cross-component references where the target is statically known. The name of the list is omitted from the path because it is universally the same as the name of the block. Used without `fk_ref`.
-- **`"node"` sentinel** — indicates a grid cell reference. The target is the parent model's spatial discretization, resolved at runtime. Used without `fk_ref` wherever a field carries a cellid (e.g., `cellid` columns, or `utl-obs.continuous.id`).
-- **Bare block name** (e.g., `"packagedata"`) — used together with `fk_ref`. `fk_ref` resolves the target component at runtime; `fk` names the block within it, in which there must be one unique `pk: true` field. Blocks not be named "node", to avoid interference with the grid cell reference sentinel.
+- **Hierarchical path**: A path of the form `"[component.]block.field"`, for use when the primary key field is statically known. The `component` segment is necessary for cross-component references; it may be omitted for within-component references. The hierarchical path form may not be used with `fk_ref`.
+- **Grid cell sentinel**: A value `"node"` indicates a grid cell reference, resolve from the parent model's grid at runtime. This form may not be used with `fk_ref`.
+- **Bare block name**: The name of a block in which there is exactly one `pk` field. In this case, `fk_ref` is required to resolve the target component at runtime. Note that blocks must not be named "node" to avoid interference with the grid cell sentinel.
 
-The `fk_ref` attribute names a sibling string field whose runtime value identifies the target component. Two sub-cases exist:
+The `fk_ref` attribute names a string field whose runtime value identifies the component containing the `pk` field. Two sub-cases exist:
 
-- **With `fk`** (bare block name): resolve the component from `fk_ref`, then find the unique `pk: true` field in the block named by `fk`. This is fully explicit and preferred when the target block is known. For all current corpus cases where `fk_ref` identifies an integer "feature number" PK (e.g. SFR, MAW, UZF, LAK via `gwf-mvr`), the block is `packagedata`; `fk: "packagedata"` should therefore always be set alongside `fk_ref` for these cases.
+- **With `fk`**: The `fk` must be a bare block name. The component containing the block is resolved with `fk_ref`, then the block (identified by `fk`) is searched for a unique `pk` field. For all current corpus cases where `fk_ref` identifies an integer "feature number" PK (e.g. SFR, MAW, UZF, LAK via `gwf-mvr`), the block is `packagedata`; `fk: "packagedata"` should therefore always be set alongside `fk_ref` for these cases.
 - **Without `fk`**: the target block varies by component (e.g. `utl-obs.continuous.id`, where the target is a boundary name whose block varies by package type).
 
 #### Examples

--- a/docs/md/sfr-lak-structure.md
+++ b/docs/md/sfr-lak-structure.md
@@ -1,0 +1,165 @@
+# SFR vs LAK: same relation, different shape
+
+Both SFR and LAK are "advanced" MODFLOW 6 packages: each defines a set of
+features (reaches / lakes) in a `packagedata` block, then references those
+features by number from several other blocks. Structurally this is the same
+one-(feature)-to-many-(rows) relation in both packages, but the two DFNs
+express it differently, and LAK's expression of it is inconsistent internally.
+This note documents the difference and suggests standardizing on LAK's
+per-row form — a change that's worth doing but not free.
+
+## SFR: one row per reach *or* per connection
+
+SFR's `connectiondata` block has exactly one row per **reach**, and each
+row's `ic` field is an inline array holding *all* of that reach's connected
+reach numbers:
+
+```
+connectiondata
+  ifno   ic
+  1      -2
+  2       1 -3
+  3       2
+```
+
+Reach 2 connects to two reaches, reach 1 and 3 connect to one each — so `ic`
+is jagged: its length varies per row, driven by another field (`ncon`) in
+that reach's `packagedata` row. The v1 DFN expresses this with a shape
+expression on `ic`: `shape (ncon(ifno))`, i.e. "look up `ncon` in the row of
+`packagedata` selected by this row's `ifno`". This idiom is how the current
+v2 migration (`_resolve_relations` in
+`modflow_devtools/dfns/migrate_to_v2_0_0_dev2.py`) originally learned that
+`packagedata.ifno` is a primary key at all — it's a side effect of parsing
+the shape expression, not a deliberate relational annotation.
+
+## LAK: one row per connection
+
+LAK's `connectiondata` normalizes the same information into one row **per
+connection** instead of per lake:
+
+```
+connectiondata
+  ifno   iconn  cellid ...
+  1      1      (1,1,1) ...
+  2      1      (1,1,2) ...
+  2      2      (1,1,3) ...
+```
+
+There's no inline jagged array and nothing to size with a shape expression —
+`ifno` is just an ordinary integer column that happens to repeat the same
+value across a lake's connections. This is why the shape-idiom detector
+never found a pk/fk relation in LAK: there's no shape expression for it to
+find. It's also arguably the cleaner of the two designs — row-per-connection
+avoids variable-length fields and reads more like a normal relational table.
+
+MAW and UZF follow LAK's row-per-connection pattern too (`ifno` repeated
+verbatim across `packagedata`, `connectiondata`/`perioddata`), and the GWT/GWE
+transport counterparts of SFR/LAK/MAW/UZF (`sft`/`lkt`/`mwt`/`uzt`,
+`sfe`/`lke`/`mwe`/`uze`) do the same with their own key names (`rno`,
+`lakeno`, `mawno`, `uzfno`). The `_resolve_relations` generalization added
+alongside this note detects all of these by matching an integer field name
+that recurs, unchanged, between `packagedata` and any other block — no shape
+expression required.
+
+## Where LAK's own naming is inconsistent
+
+Two LAK relations don't fit the "same name repeats" pattern the general
+mechanism relies on, for different reasons, and both are now patched
+explicitly in `_fix_lak_relations` (`migrate_to_v2_0_0_dev2.py`):
+
+- **`outlets.lakein` / `outlets.lakeout`** reference `packagedata.ifno`
+  unambiguously, but under different names (each row needs two lake
+  references, so they can't both be called `ifno`) — a naming gap, not an
+  ambiguity. `_fix_lak_relations` aliases both directly to
+  `fk: packagedata.ifno`, since that's correct for every row.
+- **`period.perioddata.number`** was worse than a naming gap: it's a single
+  column that means *either* a lake number (`packagedata.ifno`) or an outlet
+  number (`outlets.outletno`), depending on which keyword follows it in
+  `laksetting` (`STAGE`/`RAINFALL`/... vs. `RATE`/`INVERT`/...). A single
+  `fk` string can't correctly describe a column whose target type is
+  conditional on a sibling value — annotating it either way would be
+  actively wrong for the other half of the rows, not just imprecise. This
+  needs restructuring, not just an alias; see below.
+
+### Resolving `number`
+
+`_fix_lak_relations` splits the shared `number` field into an arm-local
+copy, pushed inside each `laksetting` union arm with a name and `fk`
+appropriate to that arm's category: `lakeno` / `fk: packagedata.ifno` for
+the 8 lake-setting arms, `outletno` / `fk: outlets.outletno` for the 5
+outlet-setting arms. (`outlets.outletno` is also newly marked `pk`, since
+nothing else previously pointed at it — needed for the new `outletno` fk to
+resolve.)
+
+This is a **schema-only** change, entirely inside `modflow-devtools`'s own
+v1→v2 migration — it does not touch the upstream MF6 `.dfn` files, MF6's
+Fortran reader, or the on-disk `.lak` file format. The token sequence MF6
+actually parses (`<number> <keyword> <value>`) is unchanged; we've only
+changed where `number` sits in *our* representation of it, so each copy can
+carry a correct, non-conditional `fk`. This mirrors existing precedent in
+the same file — `_collapse_sto_keywords` and `_wrap_oc_period_records`
+already restructure v1 fields into a different v2 shape for other packages
+without touching upstream DFNs.
+
+## Recommendation
+
+Both relations now have correct `pk`/`fk` annotations in the v2 schema, so
+neither blocks anything in this repo. `outlets.lakein`/`outlets.lakeout`
+could still be renamed upstream for clarity (e.g. `lakein_no`/`lakeout_no`,
+matching `ifno` more closely) — that would only affect generated docs/APIs
+(flopy parameter names, Fortran variable names in the LAK module), since the
+on-disk file format doesn't care what a positional column is named. MF6 has
+precedent for this kind of rename (SFR's `rno` → `ifno` between the version
+underlying this repo's older fixtures and 6.7.0). Low risk, purely cosmetic,
+worth proposing upstream on its own if desired — not something this repo
+needs.
+
+By contrast, changing the *input format itself* — e.g. requiring a
+`LAKE`/`OUTLET` discriminator keyword before `number` so the ambiguity is
+resolved in the file rather than only in our schema — would be a real
+breaking change: every existing LAK input file that sets an outlet
+property (`RATE`, `INVERT`, `WIDTH`, `ROUGH`, `SLOPE`) would need to change.
+That's not needed to fix anything in this repo (the schema-only split above
+already gives `number` a correct `pk`/`fk` representation), so it should
+only be pursued upstream, if at all, through MF6's normal deprecation path —
+not as a consequence of this document.
+
+`fk_ref` already exists in the v2 schema for harder cross-component cases
+(e.g. `gwf-mvr` referencing an arbitrary package's `packagedata` pk at
+runtime; see "Primary/foreign keys" in `docs/md/dfnspec.md`), in case some
+future relation needs real runtime resolution instead of a static `fk`.
+
+## Aside: a pre-existing, unrelated bug noticed along the way (now fixed)
+
+While tracing how LAK's `laksetting` union arms get built, one arm came out
+wrong independent of anything above: `period.perioddata.laksetting.stage`
+resolved to `type: keyword, description: "keyword to specify that record
+corresponds to stage."` — that's actually LAK's *options* block
+`stage_filerecord.stage` field (a bare keyword), not `period`'s own `stage`
+field (the real, `double precision`/time-series-capable lake stage value).
+
+The cause: `_subfield_map`/`_row_field` in `migrate_to_v2_0_0_dev2.py`
+resolved a keystring/record's named sub-fields by scanning *all* fields in
+the component (`fields.values(multi=True)`) for the first name match with
+`in_record: true`, without also requiring the match to come from the same
+block. Since v1 DFNs reuse field names across blocks routinely (`stage`
+appears in both `options` and `period` here), whichever block's field was
+declared first in the raw DFN won, regardless of which block actually
+contained the arm being resolved. This predated the changes in this
+document — it was already present in the committed `v2.0.0.dev2`/`dev3`
+snapshots — and is unrelated to pk/fk. The same bug affected every other
+package with a same-named field in two blocks, e.g. GWE/GWT's
+`temperature`/`concentration` arms resolving to their `options` filerecord
+keyword instead of their own `period` value.
+
+**Fix:** all three lookups now additionally require `fi["block"] ==
+f["block"]`, i.e. the candidate sub-field must live in the same block as the
+record/union/keystring being resolved (`f`, the enclosing field, is already
+in scope via closure). Sub-fields of a composite are always declared in that
+composite's own block, so this scoping is always correct, never just a
+best-effort heuristic. All `2.0.0.dev2`/`dev3` snapshots were regenerated
+accordingly; the only substantive diffs were the previously-misresolved
+arms (LAK's `stage`, and the analogous `temperature`/`concentration` arms in
+the GWE/GWT transport packages) — everything else in the corpus was
+unaffected, so the blast radius in practice was much narrower than the
+worst case.

--- a/modflow_devtools/dfns/migrate_to_v2_0_0_dev2.py
+++ b/modflow_devtools/dfns/migrate_to_v2_0_0_dev2.py
@@ -778,7 +778,7 @@ def _fix_lak_relations(name: str, blocks: dict[str, v2.Block]) -> dict[str, v2.B
             fields={key: renamed, arm.name: arm},
         )
 
-    new_arms: dict[str, "v2.Scalar | v2.Array | v2.Record"] = {}
+    new_arms: dict[str, v2.Scalar | v2.Array | v2.Record] = {}
     for arm_name, arm in setting_field.arms.items():
         if arm_name in _LAK_LAKE_SETTING_ARMS:
             new_arms[arm_name] = _retarget(arm_name, arm, "lakeno", "packagedata.ifno")

--- a/modflow_devtools/dfns/migrate_to_v2_0_0_dev2.py
+++ b/modflow_devtools/dfns/migrate_to_v2_0_0_dev2.py
@@ -225,7 +225,67 @@ def _resolve_dimensions(
     return blocks, array_dims
 
 
+def _collect_item_int_fields(fields: Mapping[str, v2.Field]) -> set[str]:
+    """
+    Return the names of Integer fields declared directly on a block's list-item
+    record(s) (or item union arms), one level deep. These are candidate row
+    identifiers — e.g. ``ifno`` in a ``packagedata`` recarray.
+    """
+    names: set[str] = set()
+
+    def _scan_record(record: v2.Record) -> None:
+        for fname, field in record.fields.items():
+            if isinstance(field, v2.Integer):
+                names.add(fname)
+
+    def _scan(fields: Mapping[str, v2.Field]) -> None:
+        for field in fields.values():
+            if isinstance(field, v2.Record):
+                _scan_record(field)
+            elif isinstance(field, v2.Union):
+                _scan(field.arms)
+            elif isinstance(field, v2.List):
+                item = field.item
+                if isinstance(item, v2.Record):
+                    _scan_record(item)
+                elif isinstance(item, v2.Union):
+                    _scan(item.arms)
+
+    _scan(fields)
+    return names
+
+
 def _resolve_relations(blocks: dict[str, v2.Block]) -> dict[str, v2.Block]:
+    """
+    Detect and annotate primary/foreign-key relations between a component's
+    blocks. Two independent signals are combined:
+
+    1. Shape-expression lookups: a v1 recarray shape like ``ncon(ifno)``
+       (rendered as ``packagedata.ncon(ifno)`` after v1 parsing) names an
+       array whose per-row length is looked up via a sibling ``ifno`` field
+       in another block's ``packagedata`` row. The referenced column
+       (``packagedata.ifno``) becomes ``pk``, and the sibling becomes ``fk``.
+       Currently only SFR's ``connectiondata`` uses this idiom upstream.
+
+    2. Same-name row identifiers: many advanced/multi-instance packages
+       (SFR, LAK, MAW, UZF, ...) define a numeric feature index (``ifno``,
+       or similarly) once in ``packagedata`` and repeat it, identically
+       named, as the leading column of every other block that addresses
+       the same feature (``connectiondata``, ``tables``, ``period``, ...).
+       Wherever such a name recurs outside ``packagedata``, the
+       ``packagedata`` occurrence becomes ``pk`` and the others become
+       ``fk``. This catches relations the shape idiom misses, including
+       most of SFR's own ``ifno`` columns.
+
+    Relations where the identifier is renamed (e.g. LAK's outlet-referencing
+    ``lakein``/``lakeout``) or genuinely ambiguous (e.g. LAK's period
+    ``number``, which means either a lake or an outlet number depending on
+    the setting) are intentionally not inferred here — a same-name match
+    would find nothing for the former, and would be actively wrong for the
+    latter. Both are resolved separately, by explicit patching rather than
+    name-based inference — see ``_fix_lak_relations`` and
+    ``docs/md/sfr-lak-structure.md``.
+    """
     pk_set: set[tuple[str, str]] = set()
     fk_map: dict[tuple[str, str], str] = {}
 
@@ -256,6 +316,17 @@ def _resolve_relations(blocks: dict[str, v2.Block]) -> dict[str, v2.Block]:
 
     for block_name, block in blocks.items():
         _scan_fields(block_name, block.fields)
+
+    # Signal 2: same-name row identifiers, keyed off the `packagedata` block.
+    pk_block_name = "packagedata"
+    if pk_block_name in blocks:
+        pk_names = _collect_item_int_fields(blocks[pk_block_name].fields)
+        for block_name, block in blocks.items():
+            if block_name == pk_block_name:
+                continue
+            for name in pk_names & _collect_item_int_fields(block.fields):
+                pk_set.add((pk_block_name, name))
+                fk_map.setdefault((block_name, name), f"{pk_block_name}.{name}")
 
     if not fk_map and not pk_set:
         return blocks
@@ -628,6 +699,127 @@ def _patch_oc_rtype(
     return result
 
 
+# LAK's period block pairs a single `number` field with a `laksetting` union
+# whose arms are either lake settings or outlet settings; `number` means a
+# lake number for the former, an outlet number for the latter. See
+# docs/md/sfr-lak-structure.md for the full rationale.
+_LAK_LAKE_SETTING_ARMS = frozenset(
+    {
+        "status",
+        "stage",
+        "rainfall",
+        "evaporation",
+        "runoff",
+        "inflow",
+        "withdrawal",
+        "auxiliaryrecord",
+    }
+)
+_LAK_OUTLET_SETTING_ARMS = frozenset({"rate", "invert", "width", "slope", "rough"})
+
+# outlets.lakein/lakeout are unambiguous lake references (unlike period
+# `number`), just under names that don't match packagedata's `ifno` — a
+# naming gap rather than a genuine ambiguity, so a static `fk` is correct.
+_LAK_OUTLET_LAKE_REFS = frozenset({"lakein", "lakeout"})
+
+
+def _fix_lak_relations(name: str, blocks: dict[str, v2.Block]) -> dict[str, v2.Block]:
+    """
+    Patch LAK's pk/fk relations that the general `_resolve_relations` name
+    match can't reach on its own — see docs/md/sfr-lak-structure.md.
+
+    - Splits the ambiguous period `number` field into `lakeno` / `outletno`
+      fields nested inside the corresponding `laksetting` union arms, each
+      carrying a correct, non-conditional `fk`. A single `fk` on a shared
+      `number` field can't be correct for both arm categories at once, since
+      the target block depends on which arm is present.
+    - Marks `outlets.outletno` as `pk`, since the new `outletno` fk needs a
+      pk to point to (`packagedata.ifno` is already marked by
+      `_resolve_relations`).
+    - Marks `outlets.lakein`/`outlets.lakeout` as `fk: packagedata.ifno` —
+      unlike `number`, these are unambiguous; the gap is only that their
+      names don't match `ifno`, so the general name-matching pass never
+      finds them.
+    """
+    if name != "gwf-lak":
+        return blocks
+
+    period = blocks.get("period")
+    outlets = blocks.get("outlets")
+    if period is None or outlets is None:
+        return blocks
+
+    perioddata = period.fields.get("perioddata")
+    if not isinstance(perioddata, v2.List) or not isinstance(perioddata.item, v2.Record):
+        return blocks
+    item = perioddata.item
+    number_field = item.fields.get("number")
+    setting_field = item.fields.get("laksetting")
+    if not isinstance(number_field, v2.Integer) or not isinstance(setting_field, v2.Union):
+        return blocks
+
+    outlets_list = outlets.fields.get("outlets")
+    if not isinstance(outlets_list, v2.List) or not isinstance(outlets_list.item, v2.Record):
+        return blocks
+    outletno_field = outlets_list.item.fields.get("outletno")
+    if not isinstance(outletno_field, v2.Integer):
+        return blocks
+
+    def _retarget(
+        arm_name: str, arm: "v2.Scalar | v2.Array | v2.Record", key: str, fk: str
+    ) -> v2.Record:
+        renamed = number_field.model_copy(update={"name": key, "fk": fk})
+        if isinstance(arm, v2.Record):
+            return arm.model_copy(update={"fields": {key: renamed, **arm.fields}})
+        # Most arms are a bare scalar (e.g. `stage`), not a Record — wrap it
+        # alongside the renamed id field so the id can carry its own `fk`.
+        return v2.Record(
+            name=arm_name,
+            fields={key: renamed, arm.name: arm},
+        )
+
+    new_arms: dict[str, "v2.Scalar | v2.Array | v2.Record"] = {}
+    for arm_name, arm in setting_field.arms.items():
+        if arm_name in _LAK_LAKE_SETTING_ARMS:
+            new_arms[arm_name] = _retarget(arm_name, arm, "lakeno", "packagedata.ifno")
+        elif arm_name in _LAK_OUTLET_SETTING_ARMS:
+            new_arms[arm_name] = _retarget(arm_name, arm, "outletno", "outlets.outletno")
+        else:
+            new_arms[arm_name] = arm
+
+    new_setting = setting_field.model_copy(update={"arms": new_arms})
+    new_item = item.model_copy(
+        update={
+            "fields": {fn: f for fn, f in item.fields.items() if fn != "number"}
+            | {"laksetting": new_setting}
+        }
+    )
+    new_perioddata = perioddata.model_copy(update={"item": new_item})
+    new_period = period.model_copy(
+        update={"fields": {**period.fields, "perioddata": new_perioddata}}
+    )
+
+    outlets_item_fields = dict(outlets_list.item.fields)
+    changed = False
+    if not outletno_field.pk:
+        outlets_item_fields["outletno"] = outletno_field.model_copy(update={"pk": True})
+        changed = True
+    for fname in _LAK_OUTLET_LAKE_REFS:
+        f = outlets_item_fields.get(fname)
+        if isinstance(f, v2.Integer) and f.fk is None:
+            outlets_item_fields[fname] = f.model_copy(update={"fk": "packagedata.ifno"})
+            changed = True
+
+    if changed:
+        new_outlets_item = outlets_list.item.model_copy(update={"fields": outlets_item_fields})
+        new_outlets_list = outlets_list.model_copy(update={"item": new_outlets_item})
+        new_outlets = outlets.model_copy(update={"fields": {"outlets": new_outlets_list}})
+    else:
+        new_outlets = outlets
+
+    return {**blocks, "period": new_period, "outlets": new_outlets}
+
+
 def _parse_valid(valid: Any, coerce=None) -> list | None:
     """Parse a v1 ``valid`` attribute to a list, optionally coercing each element."""
     parts = valid.split() if isinstance(valid, str) else (list(valid) if valid else [])
@@ -822,7 +1014,9 @@ def to_v2_0_0_dev2(name: str, fields: OMD, meta: list[str]) -> v2.Component:
             item_types = [
                 fi["type"]
                 for fi in fields.values(multi=True)
-                if fi["name"] in item_names and fi.get("in_record", False)
+                if fi["name"] in item_names
+                and fi.get("in_record", False)
+                and fi.get("block") == f.get("block")
             ]
 
             if (
@@ -853,7 +1047,9 @@ def to_v2_0_0_dev2(name: str, fields: OMD, meta: list[str]) -> v2.Component:
             children = {
                 fi["name"]: _map_field(fi)
                 for fi in fields.values(multi=True)
-                if fi["name"] in item_names and fi.get("in_record", False)
+                if fi["name"] in item_names
+                and fi.get("in_record", False)
+                and fi.get("block") == f.get("block")
             }
             first = next(iter(children.values()))
             if len(children) == 1 and isinstance(first, v2.Union):
@@ -870,7 +1066,11 @@ def to_v2_0_0_dev2(name: str, fields: OMD, meta: list[str]) -> v2.Component:
             result = {}
             for rname in (_type or "").split()[1:]:
                 for fi in fields.values(multi=True):
-                    if fi["name"] == rname and fi.get("in_record", False):
+                    if (
+                        fi["name"] == rname
+                        and fi.get("in_record", False)
+                        and fi.get("block") == f.get("block")
+                    ):
                         result[rname] = _map_field(fi)
                         break
             return result
@@ -1058,6 +1258,7 @@ def to_v2_0_0_dev2(name: str, fields: OMD, meta: list[str]) -> v2.Component:
     blocks = _wrap_oc_period_records(blocks)
     blocks = _collapse_sto_keywords(blocks)
     blocks = _patch_oc_rtype(name, blocks)
+    blocks = _fix_lak_relations(name, blocks)
     dims = {**explicit_dims, **array_dims, **derived_dims} or None
 
     d: dict[str, Any] = {


### PR DESCRIPTION
* two records in different blocks with identically-named fields could bleed into one another 
* integer fields that share a name between `packagedata` and another list record field (e.g. `ifno` in `connectiondata`, `tables`, `period`, ...) should be inferred as PK/FK pairs
* disambiguate LAK package `number`; previously either a lake number or an outlet number depending on which `laksetting` is active, split out separate `lakeno`/`outletno` fields to be unambiguous FKs