### PR TITLE
fix(dfns): correct fk_ref validation to match spec

### DIFF
--- a/autotest/dfns/test_schema_relations.py
+++ b/autotest/dfns/test_schema_relations.py
@@ -11,6 +11,7 @@ from modflow_devtools.dfns.schema import (
     Model,
     Package,
     Record,
+    String,
     _validate_fk_fields,
 )
 
@@ -58,16 +59,48 @@ def test_dfns_validate_fk_fields_no_pk_on_item():
         Dfns(components={"gwf-nam": gwf, "gwf-lak": lak})
 
 
+def _mvr_id_ctx(fk_val="packagedata", fk_ref="pname1", with_pname_sibling=True):
+    """
+    Build a Package mimicking gwf-mvr's period block: an `id1` field with
+    `fk`/`fk_ref` set, alongside a sibling `pname1` String field (unless
+    ``with_pname_sibling`` is False).
+    """
+    fields: dict = {"id1": Integer(name="id1", fk=fk_val, fk_ref=fk_ref)}
+    if with_pname_sibling:
+        fields["pname1"] = String(name="pname1")
+    item = Record(name="item", fields=fields)
+    lst = List(name="period", item=item)
+    block = Block(name="period", fields={"period": lst})
+    pkg = Package(name="gwf-mvr", blocks={"period": block})
+    gwf = Model(name="gwf-nam", blocks=None)
+    return pkg, gwf
+
+
 def test_dfns_validate_fk_fields_fk_ref():
-    lak, gwf = _fk_validation_ctx("packagedata", pk_on_item=True, fk_ref="gwf-nam")
-    spec = Dfns(components={"gwf-nam": gwf, "gwf-lak": lak})
-    assert "gwf-lak" in spec.components
+    # Bare block name fk + fk_ref: fk_ref must name a sibling String field.
+    # The target block/component are only resolved at runtime (from that
+    # field's value), so no local "packagedata" block or pk is required.
+    mvr, gwf = _mvr_id_ctx()
+    spec = Dfns(components={"gwf-nam": gwf, "gwf-mvr": mvr})
+    assert "gwf-mvr" in spec.components
 
 
-def test_dfns_validate_fk_fields_fk_ref_unknown():
-    lak, gwf = _fk_validation_ctx("packagedata", pk_on_item=True, fk_ref="no-such-comp")
-    with pytest.raises(ValueError, match="not found in spec"):
-        Dfns(components={"gwf-nam": gwf, "gwf-lak": lak})
+def test_dfns_validate_fk_fields_fk_ref_not_sibling():
+    mvr, gwf = _mvr_id_ctx(with_pname_sibling=False)
+    with pytest.raises(ValueError, match="not a sibling String field"):
+        Dfns(components={"gwf-nam": gwf, "gwf-mvr": mvr})
+
+
+def test_dfns_validate_fk_fields_fk_ref_with_hierarchical_fk_rejected():
+    mvr, gwf = _mvr_id_ctx(fk_val="packagedata.ifno")
+    with pytest.raises(ValueError, match="may not be combined with fk_ref"):
+        Dfns(components={"gwf-nam": gwf, "gwf-mvr": mvr})
+
+
+def test_dfns_validate_fk_fields_fk_ref_with_node_rejected():
+    mvr, gwf = _mvr_id_ctx(fk_val="node")
+    with pytest.raises(ValueError, match="may not be combined with fk_ref"):
+        Dfns(components={"gwf-nam": gwf, "gwf-mvr": mvr})
 
 
 def test_dfns_validate_fk_fields_no_fk_set():

--- a/docs/md/dfnspec.md
+++ b/docs/md/dfnspec.md
@@ -83,7 +83,6 @@ This document describes the MODFLOW 6 component definition (DFN) system. This sy
     - [Dimension sources](#dimension-sources)
     - [Dimension scope](#dimension-scope)
   - [Primary/foreign keys](#primary-and-foreign-keys)
-    - [Examples](#examples)
 - [Memory catalog](#memory-catalog)
   - [Attributes](#attributes-1)
     - [`type`](#type-2)
@@ -652,23 +651,8 @@ The `fk` attribute can take one of three forms:
 
 The `fk_ref` attribute names a string field whose runtime value identifies the component containing the `pk` field. Two sub-cases exist:
 
-- **With `fk`**: The `fk` must be a bare block name. The component containing the block is resolved with `fk_ref`, then the block (identified by `fk`) is searched for a unique `pk` field. For all current corpus cases where `fk_ref` identifies an integer "feature number" PK (e.g. SFR, MAW, UZF, LAK via `gwf-mvr`), the block is `packagedata`; `fk: "packagedata"` should therefore always be set alongside `fk_ref` for these cases.
-- **Without `fk`**: the target block varies by component (e.g. `utl-obs.continuous.id`, where the target is a boundary name whose block varies by package type).
-
-#### Examples
-
-| Field | `pk` | `fk` | `fk_ref` | Notes |
-|---|---|---|---|---|
-| `gwf-sfr.packagedata.rno` | `true` | — | — | PK of the reach list |
-| `gwf-sfr.connectiondata.rno` | — | `"packagedata.rno"` | — | FK; also row selector for ic's shape lookup |
-| `gwf-sfr.connectiondata.ic` | — | — | — | inline array; `shape: ["packagedata.ncon(rno)"]`; elements are signed reach refs (sign encodes upstream/downstream direction) |
-| `gwf-sfr.period.rno` | — | `"packagedata.rno"` | — | within-component |
-| `gwf-mvr.packages.pname` | `true` | — | — | string PK of the package list |
-| `gwf-mvr.period.pname1` | — | `"packages.pname"` | — | string FK, within-component |
-| `gwf-mvr.period.id1` | — | `"packagedata"` | `"pname1"` | component resolved from pname1; codec finds unique pk in packagedata |
-| `utl-obs.continuous.id` (string arm) | — | — | `"obstype"` | **Open:** target block varies by package type; codec must handle case-by-case |
-| `utl-obs.continuous.id` (integer arm) | — | `"node"` | — | grid cell reference |
-| `gwf-wel.period.cellid` | — | `"node"` | — | grid cell reference |
+- **With `fk`**: The `fk` must be a bare block name. The component containing the block is resolved with `fk_ref`, then the block (identified by `fk`) is searched for a unique `pk` field. This form assumes a single target block name is valid regardless of which component `fk_ref` resolves to; where that doesn't hold — the target block itself varies by the resolved component's type — a static `fk` cannot express the relation, and resolution must fall to the codec instead.
+- **Without `fk`**: the target block is not statically known at all and must be resolved by the codec, e.g. by inspecting a sibling discriminator field.
 
 ## Memory catalog
 

--- a/modflow_devtools/dfns/migrate_to_v2_0_0_dev2.py
+++ b/modflow_devtools/dfns/migrate_to_v2_0_0_dev2.py
@@ -870,8 +870,8 @@ def _fix_lak_relations(name: str, blocks: dict[str, v2.Block]) -> dict[str, v2.B
 
 def _fix_mvr_relations(name: str, blocks: dict[str, v2.Block]) -> dict[str, v2.Block]:
     """
-    Patch MVR's pk/fk relations — see docs/md/dfnspec.md, "Primary and
-    foreign keys" examples table.
+    Patch MVR's pk/fk relations that the general passes can't reach on their
+    own.
 
     - Marks `packages.pname` as `pk`: it's the unique name of a package
       participating in the mover, but nothing else in the component repeats
@@ -884,15 +884,15 @@ def _fix_mvr_relations(name: str, blocks: dict[str, v2.Block]) -> dict[str, v2.B
       `fk: "packages.pname"`, since each identifies the provider/receiver
       package by name.
 
-    Does *not* yet annotate `id1`/`id2` (documented as
-    `fk: "packagedata", fk_ref: "pname1"/"pname2"`): `_validate_fk_fields`
-    treats any `fk` as a same-component block reference and treats `fk_ref`
-    as a literal component name, neither of which matches the "bare block
-    name resolved at runtime via a sibling field" contract the docs describe
-    for this form (and no field in the current corpus exercises `fk_ref`, so
-    that contract is untested). Wiring `id1`/`id2` up needs the validator
-    fixed first, not just this migration patch — left for the broader
-    pk/fk relations review.
+    Does *not* annotate `id1`/`id2`. Each identifies a feature within the
+    package named by the sibling `pname1`/`pname2` field, but which block
+    that resolves to depends on that package's *type*: `packagedata`'s pk
+    for SFR/MAW/UZF, `outlets.outletno` (not `packagedata`'s pk) for LAK, and
+    a positional row index — not a `pk`-flagged column, and not even a
+    `packagedata` block — for ordinary boundary packages like WEL/DRN/RIV.
+    A single static `fk` value can't express that; see the pk/fk relations
+    review notes for how to represent a runtime target whose *block*, not
+    just its component, is conditional on resolved data.
     """
     if name != "gwf-mvr":
         return blocks

--- a/modflow_devtools/dfns/schema.py
+++ b/modflow_devtools/dfns/schema.py
@@ -845,10 +845,23 @@ def _validate_list_shape_element(
 
 def _validate_fk_fields(component: "ComponentBase", spec: "Dfns") -> None:
     """
-    For every Integer/String field with fk or fk_ref set, validate structure:
+    For every Integer/String field with fk or fk_ref set, validate structure.
 
-    - fk must reference a list block whose item must have at least one pk field.
-    - fk_ref must name a component that exists in the spec.
+    Three forms (see docs/md/dfnspec.md, "Primary and foreign keys"):
+
+    - Hierarchical path fk ("[component.]block.field", no fk_ref): the named
+      block must be a list block (in this component, or cross-component if
+      qualified) whose item has a pk field.
+    - "node" sentinel fk (no fk_ref): a grid cell reference, resolved from the
+      parent model's grid at runtime — no further structural check is
+      possible here.
+    - Bare block name fk + fk_ref, or fk_ref alone: fk_ref must name a sibling
+      String field in the same record, whose runtime value identifies the
+      target component (and, with fk, the pk field is looked up in the block
+      named by fk within that component). The target itself is only known at
+      runtime, so no further structural check is possible statically.
+
+    A hierarchical-path or "node" fk may not be combined with fk_ref.
     """
     if not component.blocks:
         return
@@ -858,7 +871,22 @@ def _validate_fk_fields(component: "ComponentBase", spec: "Dfns") -> None:
             fk: str | None = getattr(field, "fk", None)
             fk_ref: str | None = getattr(field, "fk_ref", None)
 
-            if fk is not None:
+            if fk_ref is not None:
+                if fk is not None and (fk == "node" or "." in fk):
+                    raise ValueError(
+                        f"Field {field.name!r}: fk={fk!r} may not be combined with "
+                        f"fk_ref (only a bare block name may be)"
+                    )
+                sibling = fields.get(fk_ref)
+                if not isinstance(sibling, String):
+                    raise ValueError(
+                        f"Field {field.name!r} fk_ref={fk_ref!r}: "
+                        f"not a sibling String field in the same record"
+                    )
+                # fk (a bare block name, if set) and the component it lives in
+                # are both resolved from fk_ref's runtime value — no further
+                # static check is possible.
+            elif fk is not None and fk != "node":
                 block_name = fk.split(".")[0] if "." in fk else fk
                 list_field = _find_list_in_block(component, block_name)
                 if list_field is None:
@@ -874,12 +902,6 @@ def _validate_fk_fields(component: "ComponentBase", spec: "Dfns") -> None:
                         f"Field {field.name!r} fk={fk!r}: "
                         f"list {list_field.name!r} item has no pk=True field"
                     )
-
-            if fk_ref is not None and fk_ref not in spec.components:
-                raise ValueError(
-                    f"Field {field.name!r} fk_ref={fk_ref!r}: "
-                    f"component {fk_ref!r} not found in spec"
-                )
 
             if isinstance(field, Record):
                 _check_fields(field.fields)


### PR DESCRIPTION
Til now `_validate_fk_fields()` checked `fk_ref` against literal component names instead of resolving it as a sibling field as prescribed in the DFN spec. Also drop the example table from the spec, it shouldn't reference specific components.